### PR TITLE
fix: Add minimum password length validation on Sign Up

### DIFF
--- a/app/src/screens/AuthScreen.js
+++ b/app/src/screens/AuthScreen.js
@@ -15,6 +15,9 @@ WebBrowser.maybeCompleteAuthSession();
 
 const { width } = Dimensions.get('window');
 
+const MIN_PASSWORD_LENGTH = 6;
+const ERR_PASSWORD_SHORT = 'Password must be at least 6 characters';
+
 export default function AuthScreen() {
   const { theme } = useTheme();
   const [isLogin, setIsLogin] = useState(true);
@@ -22,6 +25,7 @@ export default function AuthScreen() {
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
 
   const { signIn, signUp, saveGoogleAccountCredentials } = useAuth();
 
@@ -33,6 +37,10 @@ export default function AuthScreen() {
       ? (window.location.origin || process.env.EXPO_PUBLIC_REDIRECT_URI)
       : (process.env.EXPO_PUBLIC_REDIRECT_URI || makeRedirectUri({ useProxy: true })),
   });
+
+  useEffect(() => {
+    setPasswordError('');
+  }, [isLogin]);
 
   useEffect(() => {
     if (response?.type === 'error') {
@@ -115,6 +123,12 @@ export default function AuthScreen() {
       return;
     }
 
+    if (!isLogin && password.length < MIN_PASSWORD_LENGTH) {
+      setPasswordError(ERR_PASSWORD_SHORT);
+      return;
+    }
+
+    setPasswordError('');
     setLoading(true);
     try {
       if (isLogin) {
@@ -123,7 +137,11 @@ export default function AuthScreen() {
         await signUp(email, password, { displayName: name });
       }
     } catch (error) {
-      Alert.alert('Error', error.message);
+      if (error.code === 'auth/weak-password') {
+        setPasswordError(ERR_PASSWORD_SHORT);
+      } else {
+        Alert.alert('Error', error.message);
+      }
     } finally {
       setLoading(false);
     }
@@ -192,10 +210,16 @@ export default function AuthScreen() {
                 placeholder="Password"
                 placeholderTextColor={theme.colors.textSecondary}
                 value={password}
-                onChangeText={setPassword}
+                onChangeText={(text) => {
+                  setPassword(text);
+                  if (passwordError) setPasswordError('');
+                }}
                 secureTextEntry
               />
             </View>
+            {!isLogin && passwordError ? (
+              <Text style={styles.errorText}>{passwordError}</Text>
+            ) : null}
 
             <TouchableOpacity
               style={[styles.authButton, { backgroundColor: theme.colors.primary }]}
@@ -293,7 +317,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     paddingVertical: 0,
-    outlineStyle: 'none', // Remove web outline
+    outlineStyle: 'none',
     backgroundColor: 'transparent',
   },
   authButton: {
@@ -349,5 +373,11 @@ const styles = StyleSheet.create({
   footerLink: {
     fontSize: 14,
     fontWeight: 'bold',
+  },
+  errorText: {
+    color: 'red',
+    fontSize: 12,
+    marginTop: -8,
+    marginLeft: 4,
   },
 });


### PR DESCRIPTION
## 🐛 Problem
New users could sign up with a 1-character password, causing a 
confusing Firebase error instead of a clear user-facing message.

## ✅ Fix
Added client-side validation in `handleAuth` inside `AuthScreen.js`:
- When `isLogin` is `false` (Sign Up mode), checks `password.length >= 6`
- If validation fails, shows inline red error message below the 
  password field: *"Password must be at least 6 characters"*
- Error clears automatically as the user types
- Prevents Firebase call entirely if password is too short

## 📁 Files Changed
- `app/src/screens/AuthScreen.js`

## 🔗 Related Issue
Closes #40