### PR TITLE
fix: resolve high-priority storage.rules wildcard vulnerability

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,22 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
+    match /users/{uid}/avatar{
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.auth.uid == uid
+                   && request.resource.size < 5*1024*1024
+                   && request.resource.contentType.matches('image/(jpeg|png|webp)');
+    }
+    match /events/{eventId}/{file=**}{
+      allow read: if true;
+      allow write: if request.auth != null
+                   && (request.auth.token.admin == true || request.auth.token.club == true)
+                   && request.resource.size < 5*1024*1024
+                   && request.resource.contentType.matches('image/(jpeg|png|webp)');
+    }
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read, write: if false;
     }
   }
 }

--- a/tests/storage.rules.test.js
+++ b/tests/storage.rules.test.js
@@ -1,0 +1,88 @@
+const { assertFails, assertSucceeds, initializeTestEnvironment } = require('@firebase/rules-unit-testing');
+const fs = require('fs');
+
+describe('Firebase Storage Security Rules', () => {
+    let testEnv;
+
+    beforeAll(async () => {
+        testEnv = await initializeTestEnvironment({
+            projectId: "security-bug-fix-test",
+            storage: {
+                host: "127.0.0.1",
+                port: 9199,
+                rules: fs.readFileSync('storage.rules', 'utf8'),
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testEnv.cleanup();
+    });
+    
+    beforeEach(async () => {
+        await testEnv.clearStorage();
+    });
+
+    describe('Profile Photos (/users/{uid}/avatar)', () => {
+
+        it('Verify unauthorized overwrites are rejected (User A cannot overwrite User B)', async () => {
+            const attackerContext = testEnv.authenticatedContext('attacker123');
+            const attackerStorage = attackerContext.storage();
+
+            const victimAvatarRef = attackerStorage.ref('users/victim456/avatar');
+            const mockImage = new Uint8Array(1024*1024);
+            await assertFails(victimAvatarRef.put(mockImage,{contentType: 'image/png'}));
+        });
+
+        it('Verify owner can successfully upload an avatar within constraints', async () => {
+            const ownerContext = testEnv.authenticatedContext('student123');
+            const ownerStorage = ownerContext.storage();
+
+            const ownerAvatarRef = ownerStorage.ref('users/student123/avatar');
+            const mockImage = new Uint8Array(1024 * 1024); 
+            await assertSucceeds(ownerAvatarRef.put(mockImage, { contentType: 'image/jpeg' }));
+        });
+
+        it('Verify file size guard rejects files larger than 5MB', async () => {
+            const ownerContext = testEnv.authenticatedContext('student123');
+            const ownerStorage = ownerContext.storage();
+
+            const ownerAvatarRef = ownerStorage.ref('users/student123/avatar');
+            const oversizedImage = new Uint8Array(6 * 1024 * 1024);
+            await assertFails(ownerAvatarRef.put(oversizedImage, { contentType: 'image/jpeg' }));
+        });
+        
+    });
+
+    describe('Event Banners (/events/{eventId}/{file})', () => {
+
+        it('Verify normal users cannot overwrite event banners',async () => {
+            const normalUserContext = testEnv.authenticatedContext('student123');
+            const storage = normalUserContext.storage();
+
+            const bannerRef = storage.ref('events/dance-party/banner.png');
+            const mockImage = new Uint8Array(1024 * 1024);
+            await assertFails(bannerRef.put(mockImage, { contentType: 'image/png' }));
+        });
+
+        it('Verify club admins can upload event banners', async () => {
+            const adminContext = testEnv.authenticatedContext('club-prez', { club: true });
+            const storage = adminContext.storage();
+
+            const bannerRef = storage.ref('events/dance-party/banner.png');
+            const mockImage = new Uint8Array(1024);
+            await assertSucceeds(bannerRef.put(mockImage, { contentType: 'image/png' }));
+        });
+
+        it('Verify system admins can upload event banners', async () => {
+            const superAdminContext = testEnv.authenticatedContext('admin999', { admin: true });
+            const storage = superAdminContext.storage();
+
+            const bannerRef = storage.ref('events/dance-party/banner.png');
+            const mockImage = new Uint8Array(1024);
+            await assertSucceeds(bannerRef.put(mockImage, { contentType: 'image/png' }));
+        });
+    
+  });
+
+});


### PR DESCRIPTION
##Issue Number
#36 
## Description
This PR resolves the critical security vulnerability in Firebase Cloud Storage by removing the insecure `match /{allPaths=**}` wildcard rule and replacing it with strictly validated, path-specific access controls.

## Changes Made
* **Removed** the global read/write wildcard.
* **Secured Profile Photos (`/users/{uid}/avatar`)**:
  * Read access is public.
  * Write access is restricted to the authenticated owner of the `uid`.
  * Added constraints: File size must be under 5MB and content type must be an image.
* **Secured Event Banners (`/events/{eventId}/{file}`)**:
  * Read access is public.
  * Write access is strictly limited to users with custom claims (`admin` or `club`).
* **Added Test Suite**:
  * Created `tests/storage.rules.test.js` using `@firebase/rules-unit-testing`.
  * Wrote comprehensive test cases to verify both authorized and unauthorized access attempts.
  * All tests pass successfully locally via the Firebase Emulator.

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] All new and existing unit tests pass.