### PR TITLE
fix: add validation for Firebase environment variables

### DIFF
--- a/app/scripts/generate-sw.js
+++ b/app/scripts/generate-sw.js
@@ -5,19 +5,53 @@ require('dotenv').config();
 const templatePath = path.join(__dirname, '../public/firebase-messaging-sw.example.js');
 const outputPath = path.join(__dirname, '../public/firebase-messaging-sw.js');
 
+const requiredEnvVars = [
+    'EXPO_PUBLIC_FIREBASE_API_KEY',
+    'EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN',
+    'EXPO_PUBLIC_FIREBASE_PROJECT_ID',
+    'EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET',
+    'EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+    'EXPO_PUBLIC_FIREBASE_APP_ID'
+];
+
+// Validate required environment variables
+const missingVars = requiredEnvVars.filter(
+    (key) => !process.env[key]?.trim()
+);
+
+if (missingVars.length > 0) {
+    console.error('❌ Missing required Firebase environment variables:\n');
+
+    missingVars.forEach((key) => {
+        console.error(`- ${key}`);
+    });
+
+    process.exit(1);
+}
+
 try {
     let content = fs.readFileSync(templatePath, 'utf8');
 
-    content = content.replace('YOUR_API_KEY', process.env.EXPO_PUBLIC_FIREBASE_API_KEY || '');
-    content = content.replace('YOUR_AUTH_DOMAIN', process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN || '');
-    content = content.replace('YOUR_PROJECT_ID', process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID || '');
-    content = content.replace('YOUR_STORAGE_BUCKET', process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET || '');
-    content = content.replace('YOUR_MESSAGING_SENDER_ID', process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || '');
-    content = content.replace('YOUR_APP_ID', process.env.EXPO_PUBLIC_FIREBASE_APP_ID || '');
+    requiredEnvVars.forEach((key) => {
+        const placeholder = key.replace(
+            'EXPO_PUBLIC_FIREBASE_',
+            'YOUR_'
+        );
+
+        content = content.replaceAll(
+            placeholder,
+            process.env[key]
+        );
+    });
 
     fs.writeFileSync(outputPath, content);
+
     console.log('✅ firebase-messaging-sw.js generated successfully.');
 } catch (error) {
-    console.error('❌ Error generating firebase-messaging-sw.js:', error);
+    console.error(
+        '❌ Error generating firebase-messaging-sw.js:',
+        error
+    );
+
     process.exit(1);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Uni-Event",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description
Added validation for required Firebase environment variables before generating `firebase-messaging-sw.js`.

## Changes Made
- Added validation for required Firebase env variables
- Prevented silent failures caused by missing configuration
- Added descriptive error output for missing variables
- Replaced repetitive `.replace()` calls with a cleaner loop approach

## Impact
Improves developer experience and prevents invalid Firebase service worker generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build-time validation for Firebase configuration used when generating the service worker: required environment variables are now checked for presence/non-blank, missing keys are reported clearly, the build fails fast to avoid misconfigured outputs, and error/success messages are more readable for easier troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/51)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->