### PR TITLE
feat: add UniEvent Wrapped screen with yearly stats slides

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -34,6 +34,7 @@ import SavedEventsScreen from './src/screens/SavedEventsScreen';
 import FormBuilderScreen from './src/screens/FormBuilderScreen';
 import EventRegistrationFormScreen from './src/screens/EventRegistrationFormScreen';
 import WrappedScreen from './src/screens/WrappedScreen';
+import ReportBugScreen from './src/screens/ReportBugScreen';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -308,6 +309,11 @@ function Navigation() {
                             name="Wrapped"
                             component={WrappedScreen}
                             options={{ headerShown: false }}
+                        />
+                        <Stack.Screen
+                            name="ReportBug"
+                            component={ReportBugScreen}
+                            options={{ title: 'Report a Bug' }}
                         />
                     </>
                 ) : (

--- a/app/App.js
+++ b/app/App.js
@@ -33,6 +33,7 @@ import MyRegisteredEventsScreen from './src/screens/MyRegisteredEventsScreen';
 import SavedEventsScreen from './src/screens/SavedEventsScreen';
 import FormBuilderScreen from './src/screens/FormBuilderScreen';
 import EventRegistrationFormScreen from './src/screens/EventRegistrationFormScreen';
+import WrappedScreen from './src/screens/WrappedScreen';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -45,7 +46,6 @@ function HomeScreen({ navigation }) {
 
     useEffect(() => {
         const updateNavBar = async () => {
-            // Set Android Navigation Bar Color
             await NavigationBar.setBackgroundColorAsync(theme.colors.surface);
             await NavigationBar.setButtonStyleAsync(isDarkMode ? 'light' : 'dark');
         };
@@ -109,7 +109,6 @@ function HomeScreen({ navigation }) {
 }
 
 import EventAnalytics from './src/screens/EventAnalytics';
-
 import CustomTabBar from './src/components/CustomTabBar';
 import LeaderboardScreen from './src/screens/LeaderboardScreen';
 
@@ -123,7 +122,7 @@ function TabNavigator() {
             screenOptions={{
                 headerShown: false,
                 tabBarStyle: {
-                    position: 'absolute', // Required for BlurView transparency to see content behind
+                    position: 'absolute',
                     backgroundColor: 'transparent',
                     elevation: 0,
                     borderTopWidth: 0,
@@ -132,7 +131,6 @@ function TabNavigator() {
         >
             <Tab.Screen name="Home" component={HomeScreen} options={{ title: 'Home' }} />
 
-            {/* Admin Tab: Control Panel (Admin Only) */}
             {role === 'admin' && (
                 <Tab.Screen
                     name="Admin"
@@ -141,7 +139,6 @@ function TabNavigator() {
                 />
             )}
 
-            {/* My Events Tab: For Admin & Club */}
             {(role === 'admin' || role === 'club') && (
                 <Tab.Screen
                     name="MyEvents"
@@ -156,7 +153,6 @@ function TabNavigator() {
                 options={{ title: 'Reminders' }}
             />
 
-            {/* Leaderboard for everyone or students */}
             <Tab.Screen
                 name="Leaderboard"
                 component={LeaderboardScreen}
@@ -243,7 +239,6 @@ function Navigation() {
                             component={ParticipatingEventsScreen}
                             options={{ title: "Events I'm Going To" }}
                         />
-                        {/* MyEvents is now a Tab, but can still be navigated to if needed, though usually via tab */}
                         <Stack.Screen
                             name="EventAnalytics"
                             component={EventAnalytics}
@@ -259,8 +254,6 @@ function Navigation() {
                             component={QRScannerScreen}
                             options={{ title: 'Scan QR', headerShown: false }}
                         />
-
-                        {/* Migrated Screens */}
                         <Stack.Screen
                             name="Appearance"
                             component={AppearanceScreen}
@@ -311,6 +304,11 @@ function Navigation() {
                             component={EventRegistrationFormScreen}
                             options={{ headerShown: false }}
                         />
+                        <Stack.Screen
+                            name="Wrapped"
+                            component={WrappedScreen}
+                            options={{ headerShown: false }}
+                        />
                     </>
                 ) : (
                     <Stack.Screen
@@ -329,7 +327,6 @@ import { doc, updateDoc } from 'firebase/firestore';
 import { useRef } from 'react';
 import { db } from './src/lib/firebaseConfig';
 import { registerForPushNotificationsAsync } from './src/lib/notificationService';
-
 import PWAInstallPrompt from './src/components/PWAInstallPrompt';
 
 export default function App() {
@@ -353,28 +350,23 @@ function AppContent() {
     useEffect(() => {
         registerForPushNotificationsAsync().then(token => {
             if (user && token) {
-                // Save token to user profile
                 updateDoc(doc(db, 'users', user.uid), {
                     pushToken: token,
                 }).catch(err => console.log('Failed to save push token', err));
-
-                // Global Automation Check - DISABLED (Manual feedback sending only)
-                // checkAndTriggerAutomations(user.uid);
             }
         });
+        // Global Automation Check - DISABLED (Manual feedback sending only)
+        // checkAndTriggerAutomations(user.uid);
 
-        // Listeners for foreground notifications
         notificationListener.current = Notifications.addNotificationReceivedListener(
             notification => {
                 console.log('Notification Received:', notification);
             },
         );
 
-        // Listeners for user interacting with notification
         responseListener.current = Notifications.addNotificationResponseReceivedListener(
             response => {
                 console.log('Notification Tapped:', response);
-                // Could navigate to event detail here
             },
         );
 

--- a/app/src/components/WrappedConfetti.js
+++ b/app/src/components/WrappedConfetti.js
@@ -1,0 +1,395 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { useEffect, useRef } from 'react';
+import { Animated, Dimensions, Easing, Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTheme } from '../lib/ThemeContext';
+
+const { width, height } = Dimensions.get('window');
+
+const CONFETTI_COLORS = [
+    '#FFB74D', '#FF6B6B', '#7B61FF',
+    '#00C9A7', '#FFD600', '#2979FF',
+    '#FF4081', '#00E5FF', '#FF9800',
+    '#4CAF50', '#E91E63', '#9C27B0',
+];
+
+export default function WrappedConfetti({ visible, onComplete }) {
+    const { theme } = useTheme();
+
+    const fadeAnim = useRef(new Animated.Value(0)).current;
+    const scaleAnim = useRef(new Animated.Value(0)).current;
+    const checkmarkScale = useRef(new Animated.Value(0)).current;
+    const cardSlide = useRef(new Animated.Value(100)).current;
+
+    const ripple1 = useRef(new Animated.Value(0)).current;
+    const ripple2 = useRef(new Animated.Value(0)).current;
+    const ripple3 = useRef(new Animated.Value(0)).current;
+
+    const rippleLoopsRef = useRef([]);
+    const timeoutIdsRef = useRef([]);
+
+    const particles = useRef(
+        CONFETTI_COLORS.map(() => ({
+            x: new Animated.Value(0),
+            y: new Animated.Value(0),
+            opacity: new Animated.Value(0),
+            scale: new Animated.Value(0),
+            rotate: new Animated.Value(0),
+        }))
+    ).current;
+
+    useEffect(() => {
+        if (!visible) return;
+
+        // Reset all
+        fadeAnim.setValue(0);
+        scaleAnim.setValue(0);
+        checkmarkScale.setValue(0);
+        cardSlide.setValue(100);
+        ripple1.setValue(0);
+        ripple2.setValue(0);
+        ripple3.setValue(0);
+        particles.forEach(p => {
+            p.x.setValue(0);
+            p.y.setValue(0);
+            p.opacity.setValue(0);
+            p.scale.setValue(0);
+            p.rotate.setValue(0);
+        });
+
+        // 1. Fade in overlay
+        Animated.timing(fadeAnim, {
+            toValue: 1,
+            duration: 200,
+            useNativeDriver: true,
+        }).start();
+
+        // 2. Main circle pop
+        Animated.spring(scaleAnim, {
+            toValue: 1,
+            friction: 6,
+            tension: 40,
+            useNativeDriver: true,
+        }).start();
+
+        // 3. Ripples
+        const rippleAnim = (anim, delay) =>
+            Animated.loop(
+                Animated.sequence([
+                    Animated.delay(delay),
+                    Animated.timing(anim, {
+                        toValue: 1,
+                        duration: 1500,
+                        easing: Easing.out(Easing.ease),
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(anim, {
+                        toValue: 0,
+                        duration: 0,
+                        useNativeDriver: true,
+                    }),
+                ]),
+            );
+
+        const loop1 = rippleAnim(ripple1, 0);
+        const loop2 = rippleAnim(ripple2, 400);
+        const loop3 = rippleAnim(ripple3, 800);
+        rippleLoopsRef.current = [loop1, loop2, loop3];
+        rippleLoopsRef.current.forEach(loop => loop.start());
+
+        // 4. Confetti burst
+        const burstTimeout = setTimeout(() => {
+            const angles = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
+            particles.forEach((p, i) => {
+                const angle = (angles[i] * Math.PI) / 180;
+                const distance = 130 + Math.random() * 80;
+                Animated.parallel([
+                    Animated.timing(p.opacity, {
+                        toValue: 1,
+                        duration: 200,
+                        useNativeDriver: true,
+                    }),
+                    Animated.spring(p.scale, {
+                        toValue: 1,
+                        friction: 4,
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(p.x, {
+                        toValue: Math.cos(angle) * distance,
+                        duration: 700,
+                        easing: Easing.out(Easing.back(1.2)),
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(p.y, {
+                        toValue: Math.sin(angle) * distance,
+                        duration: 700,
+                        easing: Easing.out(Easing.back(1.2)),
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(p.rotate, {
+                        toValue: 1,
+                        duration: 700,
+                        useNativeDriver: true,
+                    }),
+                ]).start(() => {
+                    Animated.timing(p.opacity, {
+                        toValue: 0,
+                        duration: 500,
+                        useNativeDriver: true,
+                    }).start();
+                });
+            });
+        }, 300);
+        timeoutIdsRef.current.push(burstTimeout);
+
+        // 5a. Star appears fast
+        const starTimeout = setTimeout(() => {
+            Animated.spring(checkmarkScale, {
+                toValue: 1,
+                friction: 5,
+                tension: 50,
+                useNativeDriver: true,
+            }).start();
+        }, 200);
+        timeoutIdsRef.current.push(starTimeout);
+
+        // 5b. Card slides up after confetti
+        const cardTimeout = setTimeout(() => {
+            Animated.spring(cardSlide, {
+                toValue: 0,
+                friction: 8,
+                tension: 40,
+                useNativeDriver: true,
+            }).start();
+        }, 1500);
+        timeoutIdsRef.current.push(cardTimeout);
+
+        // 6. No auto dismiss — user clicks button
+
+        return () => {
+            rippleLoopsRef.current.forEach(loop => loop.stop());
+            rippleLoopsRef.current = [];
+            timeoutIdsRef.current.forEach(id => clearTimeout(id));
+            timeoutIdsRef.current = [];
+        };
+    }, [visible]);
+
+    const handleDismiss = () => {
+        Animated.timing(fadeAnim, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: true,
+        }).start(() => {
+            if (onComplete) onComplete();
+        });
+    };
+
+    if (!visible) return null;
+
+    return (
+        <Modal visible={visible} transparent animationType="none" statusBarTranslucent>
+            <Animated.View
+                style={[
+                    styles.container,
+                    { opacity: fadeAnim, backgroundColor: theme.colors.background },
+                ]}
+            >
+                {/* Ripples */}
+                {[ripple1, ripple2, ripple3].map((ripple, i) => (
+                    <Animated.View
+                        key={i}
+                        style={[
+                            styles.ripple,
+                            {
+                                backgroundColor: theme.colors.primary,
+                                transform: [{
+                                    scale: ripple.interpolate({
+                                        inputRange: [0, 1],
+                                        outputRange: [0.8, 3],
+                                    }),
+                                }],
+                                opacity: ripple.interpolate({
+                                    inputRange: [0, 1],
+                                    outputRange: [0.15, 0],
+                                }),
+                            },
+                        ]}
+                    />
+                ))}
+
+                {/* Confetti particles */}
+                {particles.map((p, i) => (
+                    <Animated.View
+                        key={i}
+                        style={[
+                            styles.particle,
+                            {
+                                backgroundColor: CONFETTI_COLORS[i],
+                                transform: [
+                                    { translateX: p.x },
+                                    { translateY: p.y },
+                                    { scale: p.scale },
+                                    {
+                                        rotate: p.rotate.interpolate({
+                                            inputRange: [0, 1],
+                                            outputRange: ['0deg', '360deg'],
+                                        }),
+                                    },
+                                ],
+                                opacity: p.opacity,
+                            },
+                        ]}
+                    />
+                ))}
+
+                {/* Main circle */}
+                <Animated.View
+                    style={[
+                        styles.circleWrapper,
+                        {
+                            transform: [{ scale: scaleAnim }],
+                            backgroundColor: theme.colors.surface,
+                        },
+                    ]}
+                >
+                    <LinearGradient
+                        colors={[theme.colors.primary, theme.colors.secondary]}
+                        start={{ x: 0, y: 0 }}
+                        end={{ x: 1, y: 1 }}
+                        style={styles.circle}
+                    >
+                        <Animated.View style={{ transform: [{ scale: checkmarkScale }] }}>
+                            <Text style={styles.starEmoji}>🌟</Text>
+                        </Animated.View>
+                    </LinearGradient>
+                </Animated.View>
+
+                {/* Card */}
+                <Animated.View
+                    style={[
+                        styles.card,
+                        {
+                            backgroundColor: theme.colors.surface,
+                            opacity: checkmarkScale,
+                            transform: [{ translateY: cardSlide }],
+                        },
+                    ]}
+                >
+                    <Text style={[styles.title, { color: theme.colors.text }]}>
+                        UniEvent Wrapped
+                    </Text>
+                    <Text style={[styles.subtitle, { color: theme.colors.primary }]}>
+                        Your year in review!
+                    </Text>
+                    <View style={[styles.divider, { backgroundColor: theme.colors.border }]} />
+
+                    <TouchableOpacity
+                        style={[styles.btn, { backgroundColor: theme.colors.primary }]}
+                        onPress={handleDismiss}
+                    >
+                        <Text style={styles.btnText}>See My Stats →</Text>
+                    </TouchableOpacity>
+                </Animated.View>
+
+                {/* Footer */}
+                <Animated.Text
+                    style={[
+                        styles.footer,
+                        { color: theme.colors.textSecondary, opacity: checkmarkScale },
+                    ]}
+                >
+                    Powered by UniEvent
+                </Animated.Text>
+            </Animated.View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    ripple: {
+        position: 'absolute',
+        width: 120,
+        height: 120,
+        borderRadius: 60,
+        zIndex: -1,
+    },
+    particle: {
+        position: 'absolute',
+        width: 10,
+        height: 10,
+        borderRadius: 3,
+    },
+    circleWrapper: {
+        width: 100,
+        height: 100,
+        borderRadius: 50,
+        justifyContent: 'center',
+        alignItems: 'center',
+        elevation: 10,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.2,
+        shadowRadius: 8,
+        marginBottom: 24,
+    },
+    circle: {
+        width: '100%',
+        height: '100%',
+        borderRadius: 50,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    starEmoji: {
+        fontSize: 44,
+    },
+    card: {
+        width: width * 0.78,
+        padding: 18,
+        borderRadius: 32,
+        alignItems: 'center',
+        elevation: 5,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 10 },
+        shadowOpacity: 0.1,
+        shadowRadius: 20,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        marginBottom: 6,
+    },
+    subtitle: {
+        fontSize: 15,
+        fontWeight: '600',
+        marginBottom: 16,
+    },
+    divider: {
+        width: '100%',
+        height: 1,
+        marginBottom: 14,
+        opacity: 0.5,
+    },
+    btn: {
+        paddingHorizontal: 28,
+        paddingVertical: 11,
+        borderRadius: 24,
+        marginTop: 2,
+    },
+    btnText: {
+        color: '#fff',
+        fontWeight: '700',
+        fontSize: 15,
+    },
+    footer: {
+        position: 'absolute',
+        bottom: 50,
+        fontSize: 12,
+        fontWeight: '500',
+        letterSpacing: 1,
+        textTransform: 'uppercase',
+    },
+});

--- a/app/src/screens/ProfileScreen.js
+++ b/app/src/screens/ProfileScreen.js
@@ -524,10 +524,18 @@ export default function ProfileScreen({ navigation }) {
                                     styles={styles}
                                 />
                                 <View style={styles.divider} />
-                                <MenuItem
+                               <MenuItem
                                     icon="bookmark-outline"
                                     label="Saved Events"
                                     onPress={() => navigation.navigate('SavedEvents')}
+                                    theme={theme}
+                                    styles={styles}
+                                />
+                                <View style={styles.divider} />
+                                <MenuItem
+                                    icon="sparkles-outline"
+                                    label="My Wrapped"
+                                    onPress={() => navigation.navigate('Wrapped')}
                                     theme={theme}
                                     styles={styles}
                                 />

--- a/app/src/screens/WrappedScreen.js
+++ b/app/src/screens/WrappedScreen.js
@@ -1,0 +1,487 @@
+import { Ionicons } from '@expo/vector-icons';
+import { collection, getDocs } from 'firebase/firestore';
+import { useMemo, useState, useEffect, useRef } from 'react';
+import {
+    Animated,
+    Dimensions,
+    ScrollView,
+    Share,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import ScreenWrapper from '../components/ScreenWrapper';
+import WrappedConfetti from '../components/WrappedConfetti';
+import { useAuth } from '../lib/AuthContext';
+import { db } from '../lib/firebaseConfig';
+import { useTheme } from '../lib/ThemeContext';
+
+const { width } = Dimensions.get('window');
+
+const MONTH_NAMES = [
+    'January','February','March','April','May','June',
+    'July','August','September','October','November','December'
+];
+
+// Auto academic year — always current
+const now = new Date();
+const startYear = now.getMonth() >= 7 ? now.getFullYear() : now.getFullYear() - 1;
+const academicYearLabel = `${startYear} — ${startYear + 1}`;
+const academicStart = new Date(startYear, 7, 1);             // Aug 1
+const academicEndExclusive = new Date(startYear + 1, 7, 1); // Aug 1 next year (exclusive)
+
+export default function WrappedScreen({ navigation }) {
+    const { user } = useAuth();
+    const { theme } = useTheme();
+    const styles = useMemo(() => getStyles(theme), [theme]);
+
+    const [current, setCurrent] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [showIntro, setShowIntro] = useState(true);
+    const [stats, setStats] = useState({
+        totalEvents: 0,
+        mostActiveMonth: 'N/A',
+        favoriteCategory: 'N/A',
+        totalPoints: 0,
+    });
+
+    const fadeAnim = useRef(new Animated.Value(1)).current;
+
+    useEffect(() => {
+        if (!user?.uid) return;
+        fetchWrappedStats(user.uid);
+    }, [user?.uid]);
+
+    const fetchWrappedStats = async (uid) => {
+        try {
+            const participatingRef = collection(db, 'users', uid, 'participating');
+            const snapshot = await getDocs(participatingRef);
+
+            const events = snapshot.docs
+                .map(d => d.data())
+                .filter(e => {
+                    if (!e.registeredAt) return false;
+                    const date = e.registeredAt.toDate
+                        ? e.registeredAt.toDate()
+                        : new Date(e.registeredAt);
+                    if (Number.isNaN(date.getTime())) return false;
+                    return date >= academicStart && date < academicEndExclusive;
+                });
+
+            const total = events.length;
+
+            // Most active month
+            const monthCount = {};
+            events.forEach(e => {
+                if (e.registeredAt) {
+                    const date = e.registeredAt.toDate
+                        ? e.registeredAt.toDate()
+                        : new Date(e.registeredAt);
+                    const month = date.getMonth();
+                    monthCount[month] = (monthCount[month] || 0) + 1;
+                }
+            });
+            const activeMonthIndex = Object.keys(monthCount).sort(
+                (a, b) => monthCount[b] - monthCount[a]
+            )[0];
+            const activeMonth = activeMonthIndex !== undefined
+                ? MONTH_NAMES[parseInt(activeMonthIndex)]
+                : 'N/A';
+
+            // Favorite category
+            const catCount = {};
+            events.forEach(e => {
+                if (e.category) {
+                    catCount[e.category] = (catCount[e.category] || 0) + 1;
+                }
+            });
+            const favCategory = Object.keys(catCount).sort(
+                (a, b) => catCount[b] - catCount[a]
+            )[0] || 'N/A';
+
+            setStats({
+                totalEvents: total,
+                mostActiveMonth: activeMonth,
+                favoriteCategory: favCategory,
+                totalPoints: total * 10,
+            });
+        } catch (e) {
+            console.error('Wrapped fetch error:', e);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const slides = [
+        {
+            id: 1,
+            icon: 'calendar-outline',
+            title: 'Your Year in Events',
+            value: String(stats.totalEvents),
+            subtitle: 'events attended this year',
+            accent: theme.colors.primary,
+        },
+        {
+            id: 2,
+            icon: 'flame-outline',
+            title: 'Most Active Month',
+            value: stats.mostActiveMonth,
+            subtitle: 'you were on fire!',
+            accent: '#FF6B6B',
+        },
+        {
+            id: 3,
+            icon: 'star-outline',
+            title: 'Favourite Category',
+            value: stats.favoriteCategory,
+            subtitle: 'your go-to event type',
+            accent: theme.colors.info,
+        },
+        {
+            id: 4,
+            icon: 'trophy-outline',
+            title: 'Points Earned',
+            value: String(stats.totalPoints),
+            subtitle: 'reputation points collected',
+            accent: theme.colors.success,
+        },
+        {
+            id: 5,
+            icon: 'heart-outline',
+            title: 'You are a Campus Star!',
+            value: 'Amazing',
+            subtitle: 'thanks for making campus life better',
+            accent: theme.colors.primary,
+        },
+    ];
+
+    const animateTransition = (callback) => {
+        Animated.timing(fadeAnim, { toValue: 0, duration: 150, useNativeDriver: true }).start(() => {
+            callback();
+            Animated.timing(fadeAnim, { toValue: 1, duration: 150, useNativeDriver: true }).start();
+        });
+    };
+
+    const goNext = () => {
+        if (current < slides.length - 1) animateTransition(() => setCurrent(c => c + 1));
+    };
+
+    const goPrev = () => {
+        if (current > 0) animateTransition(() => setCurrent(c => c - 1));
+    };
+
+    const handleShare = async () => {
+        try {
+            await Share.share({
+                message:
+                    `🎉 My UniEvent Wrapped ${academicYearLabel}!\n\n` +
+                    `📅 Events Attended: ${stats.totalEvents}\n` +
+                    `🔥 Most Active Month: ${stats.mostActiveMonth}\n` +
+                    `⭐ Favourite Category: ${stats.favoriteCategory}\n` +
+                    `🏆 Points Earned: ${stats.totalPoints}\n\n` +
+                    `Check out UniEvent for your campus events!`,
+            });
+        } catch (e) {
+            console.error(e);
+        }
+    };
+
+    const slide = slides[current];
+    const isLast = current === slides.length - 1;
+
+    if (loading) {
+        return (
+            <ScreenWrapper>
+                <View style={styles.loadingContainer}>
+                    <Text style={styles.loadingText}>Calculating your year...</Text>
+                </View>
+            </ScreenWrapper>
+        );
+    }
+
+    return (
+        <ScreenWrapper>
+            <ScrollView
+                contentContainerStyle={styles.scrollContent}
+                showsVerticalScrollIndicator={false}
+            >
+                {/* Header */}
+                <View style={styles.header}>
+                    <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+                        <Ionicons name="arrow-back" size={22} color={theme.colors.text} />
+                    </TouchableOpacity>
+                    <Text style={styles.headerTitle}>UniEvent Wrapped</Text>
+                    <TouchableOpacity onPress={handleShare} style={styles.shareBtn}>
+                        <Ionicons name="share-outline" size={22} color={theme.colors.primary} />
+                    </TouchableOpacity>
+                </View>
+
+                {/* Auto year label */}
+                <Text style={styles.yearLabel}>{academicYearLabel}</Text>
+
+                {/* Slide Card */}
+                <Animated.View style={[styles.card, { opacity: fadeAnim }]}>
+                    <View style={[styles.accentBar, { backgroundColor: slide.accent }]} />
+                    <View style={[styles.iconCircle, { backgroundColor: slide.accent + '20' }]}>
+                        <Ionicons name={slide.icon} size={36} color={slide.accent} />
+                    </View>
+                    <Text style={styles.slideTitle}>{slide.title}</Text>
+                    <Text style={[styles.slideValue, { color: slide.accent }]}>{slide.value}</Text>
+                    <Text style={styles.slideSubtitle}>{slide.subtitle}</Text>
+                </Animated.View>
+
+                {/* Dot indicators */}
+                <View style={styles.dots}>
+                    {slides.map((_, i) => (
+                        <TouchableOpacity key={i} onPress={() => setCurrent(i)}>
+                            <View style={[
+                                styles.dot,
+                                i === current && { backgroundColor: theme.colors.primary, width: 24 }
+                            ]} />
+                        </TouchableOpacity>
+                    ))}
+                </View>
+
+                {/* Navigation buttons */}
+                <View style={styles.navRow}>
+                    <TouchableOpacity
+                        style={[styles.navBtn, current === 0 && styles.navBtnDisabled]}
+                        onPress={goPrev}
+                        disabled={current === 0}
+                    >
+                        <Ionicons
+                            name="arrow-back"
+                            size={20}
+                            color={current === 0 ? theme.colors.textSecondary : theme.colors.text}
+                        />
+                        <Text style={[
+                            styles.navBtnText,
+                            { color: current === 0 ? theme.colors.textSecondary : theme.colors.text }
+                        ]}>Back</Text>
+                    </TouchableOpacity>
+
+                    {isLast ? (
+                        <TouchableOpacity style={styles.shareFullBtn} onPress={handleShare}>
+                            <Ionicons name="share-social-outline" size={20} color="#fff" />
+                            <Text style={styles.shareFullBtnText}>Share My Wrapped</Text>
+                        </TouchableOpacity>
+                    ) : (
+                        <TouchableOpacity style={styles.nextBtn} onPress={goNext}>
+                            <Text style={styles.nextBtnText}>Next</Text>
+                            <Ionicons name="arrow-forward" size={20} color="#fff" />
+                        </TouchableOpacity>
+                    )}
+                </View>
+
+                {/* Stats summary */}
+                <View style={styles.summaryRow}>
+                    <View style={[styles.summaryCard, { backgroundColor: theme.colors.surface }]}>
+                        <Ionicons name="calendar-outline" size={18} color={theme.colors.primary} />
+                        <Text style={styles.summaryValue}>{stats.totalEvents}</Text>
+                        <Text style={styles.summaryLabel}>Events</Text>
+                    </View>
+                    <View style={[styles.summaryCard, { backgroundColor: theme.colors.surface }]}>
+                        <Ionicons name="star-outline" size={18} color={theme.colors.primary} />
+                        <Text style={styles.summaryValue} numberOfLines={1}>{stats.favoriteCategory}</Text>
+                        <Text style={styles.summaryLabel}>Top Category</Text>
+                    </View>
+                    <View style={[styles.summaryCard, { backgroundColor: theme.colors.surface }]}>
+                        <Ionicons name="trophy-outline" size={18} color={theme.colors.primary} />
+                        <Text style={styles.summaryValue}>{stats.totalPoints}</Text>
+                        <Text style={styles.summaryLabel}>Points</Text>
+                    </View>
+                </View>
+            </ScrollView>
+
+            {/* Confetti intro animation */}
+            <WrappedConfetti
+                visible={showIntro}
+                onComplete={() => setShowIntro(false)}
+            />
+        </ScreenWrapper>
+    );
+}
+
+const getStyles = theme => StyleSheet.create({
+    scrollContent: {
+        paddingBottom: 100,
+        paddingHorizontal: theme.spacing.m,
+    },
+    loadingContainer: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    loadingText: {
+        fontSize: 18,
+        color: theme.colors.primary,
+        fontWeight: '600',
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingVertical: theme.spacing.m,
+    },
+    backBtn: {
+        padding: 8,
+        borderRadius: 12,
+        backgroundColor: theme.colors.surface,
+    },
+    headerTitle: {
+        fontSize: 18,
+        fontWeight: '700',
+        color: theme.colors.text,
+    },
+    shareBtn: {
+        padding: 8,
+        borderRadius: 12,
+        backgroundColor: theme.colors.surface,
+    },
+    yearLabel: {
+        textAlign: 'center',
+        fontSize: 13,
+        color: theme.colors.textSecondary,
+        marginBottom: theme.spacing.m,
+        fontWeight: '600',
+        letterSpacing: 1,
+    },
+    card: {
+        backgroundColor: theme.colors.surface,
+        borderRadius: 24,
+        padding: theme.spacing.l,
+        alignItems: 'center',
+        minHeight: 280,
+        justifyContent: 'center',
+        overflow: 'hidden',
+        ...theme.shadows.default,
+    },
+    accentBar: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 4,
+        borderTopLeftRadius: 24,
+        borderTopRightRadius: 24,
+    },
+    iconCircle: {
+        width: 80,
+        height: 80,
+        borderRadius: 40,
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginBottom: theme.spacing.m,
+    },
+    slideTitle: {
+        fontSize: 14,
+        fontWeight: '600',
+        color: theme.colors.textSecondary,
+        textAlign: 'center',
+        marginBottom: 8,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+    },
+    slideValue: {
+        fontSize: 48,
+        fontWeight: '800',
+        textAlign: 'center',
+        marginBottom: 8,
+    },
+    slideSubtitle: {
+        fontSize: 15,
+        color: theme.colors.textSecondary,
+        textAlign: 'center',
+    },
+    dots: {
+        flexDirection: 'row',
+        justifyContent: 'center',
+        gap: 6,
+        marginVertical: theme.spacing.m,
+    },
+    dot: {
+        width: 8,
+        height: 8,
+        borderRadius: 4,
+        backgroundColor: theme.colors.border,
+    },
+    navRow: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: theme.spacing.l,
+        gap: 12,
+    },
+    navBtn: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        padding: 12,
+        borderRadius: 14,
+        backgroundColor: theme.colors.surface,
+        borderWidth: 1,
+        borderColor: theme.colors.border,
+    },
+    navBtnDisabled: {
+        opacity: 0.4,
+    },
+    navBtnText: {
+        fontSize: 15,
+        fontWeight: '600',
+    },
+    nextBtn: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        padding: 14,
+        borderRadius: 14,
+        backgroundColor: theme.colors.primary,
+    },
+    nextBtnText: {
+        color: '#fff',
+        fontSize: 16,
+        fontWeight: '700',
+    },
+    shareFullBtn: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        padding: 14,
+        borderRadius: 14,
+        backgroundColor: theme.colors.success,
+    },
+    shareFullBtnText: {
+        color: '#fff',
+        fontSize: 16,
+        fontWeight: '700',
+    },
+    summaryRow: {
+        flexDirection: 'row',
+        gap: 10,
+        marginTop: 4,
+    },
+    summaryCard: {
+        flex: 1,
+        alignItems: 'center',
+        padding: 12,
+        borderRadius: 16,
+        gap: 4,
+        ...theme.shadows.small,
+    },
+    summaryValue: {
+        fontSize: 13,
+        fontWeight: '700',
+        color: theme.colors.text,
+        textAlign: 'center',
+    },
+    summaryLabel: {
+        fontSize: 11,
+        color: theme.colors.textSecondary,
+        fontWeight: '500',
+    },
+});


### PR DESCRIPTION
# Description
Adds a personalized "UniEvent Wrapped" screen for each student showing 
their yearly campus event stats in a series of swipeable slides.
Aggregates Firestore data from the user's participating subcollection 
and presents it in mobile-friendly slides with smooth animations.

Fixes #62

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested locally on web browser via Expo web (localhost:19006).

Steps to reproduce:
1. Run `npm start` inside the `app` folder
2. Log in with any account
3. Go to Profile tab
4. Tap "My Wrapped " menu item
5. Swipe through the 5 slides
6. Tap share button on last slide

Test configuration:
- Expo SDK 49
- Web browser (Chrome)
- Firebase Firestore connected

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules.
<img width="3835" height="1667" alt="image" src="https://github.com/user-attachments/assets/c08dd551-c291-45b9-b28a-f0b03d131bc3" />
<img width="3839" height="1899" alt="image" src="https://github.com/user-attachments/assets/6f76de37-4456-4d86-aed0-5ad0119365e7" />
<img width="3839" height="1655" alt="image" src="https://github.com/user-attachments/assets/075cca4b-6891-41e4-a6a9-68d1b0150fc3" />
<img width="3839" height="1648" alt="image" src="https://github.com/user-attachments/assets/28057273-f2b0-4708-99a9-dffcaf7474e5" />
<img width="3839" height="1630" alt="image" src="https://github.com/user-attachments/assets/6514bd1b-abb3-4c1a-8e99-9cde806aaac3" />
<img width="3839" height="1586" alt="image" src="https://github.com/user-attachments/assets/12b78434-9549-4481-b122-678e05d44a04" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "My Wrapped" year-in-review added to Activity menu.
  * Personalized stats: events attended, most active month, favorite category, and points.
  * 5-slide carousel with transitions, dot navigation, loading state, header share and in-app share button.
  * Festive confetti intro overlay with animated reveal.

* **Chores**
  * Minor navigation, push-notification flow formatting, and tab-bar layout tweaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->