### PR TITLE
Implement real pull-to-refresh logic in RemindersScreen

### DIFF
--- a/app/src/screens/RemindersScreen.js
+++ b/app/src/screens/RemindersScreen.js
@@ -35,6 +35,45 @@ export default function RemindersScreen({ navigation }) {
         };
     }, []);
 
+    const processRemindersSnapshot = async (snapshot) => {
+        const list = [];
+        await Promise.all(
+            snapshot.docs.map(async docSnap => {
+                const data = docSnap.data();
+                let eventTitle = 'Event';
+                let eventLocation = '';
+                let bannerUrl = null;
+                try {
+                    const eventDoc = await getDoc(doc(db, 'events', data.eventId));
+                    if (eventDoc.exists()) {
+                        const ed = eventDoc.data();
+                        eventTitle = ed.title;
+                        eventLocation = ed.location;
+                        bannerUrl = ed.bannerUrl;
+                    }
+                } catch (e) {
+                    console.error('Error fetching event details for reminder:', e);
+                }
+
+                list.push({
+                    id: docSnap.id,
+                    eventTitle,
+                    eventLocation,
+                    bannerUrl,
+                    ...data,
+                });
+            }),
+        );
+
+        list.sort((a, b) => {
+            const da = a.remindAt?.toDate ? a.remindAt.toDate() : new Date(a.remindAt);
+            const db = b.remindAt?.toDate ? b.remindAt.toDate() : new Date(b.remindAt);
+            return da - db;
+        });
+
+        return list;
+    };
+
     useEffect(() => {
         if (!user) return;
 
@@ -44,44 +83,7 @@ export default function RemindersScreen({ navigation }) {
         const unsubscribe = onSnapshot(
             q,
             async snapshot => {
-                const list = [];
-                // Parallel fetch for speed
-                await Promise.all(
-                    snapshot.docs.map(async docSnap => {
-                        const data = docSnap.data();
-                        let eventTitle = 'Event';
-                        let eventLocation = '';
-                        let bannerUrl = null;
-                        try {
-                            // We could cache this or use a separate listener but for now this is fine
-                            const eventDoc = await getDoc(doc(db, 'events', data.eventId));
-                            if (eventDoc.exists()) {
-                                const ed = eventDoc.data();
-                                eventTitle = ed.title;
-                                eventLocation = ed.location;
-                                bannerUrl = ed.bannerUrl;
-                            }
-                        } catch (e) {
-                            console.log(e);
-                        }
-
-                        list.push({
-                            id: docSnap.id,
-                            eventTitle,
-                            eventLocation,
-                            bannerUrl,
-                            ...data,
-                        });
-                    }),
-                );
-
-                // Sort by remindAt
-                list.sort((a, b) => {
-                    const da = a.remindAt?.toDate ? a.remindAt.toDate() : new Date(a.remindAt);
-                    const db = b.remindAt?.toDate ? b.remindAt.toDate() : new Date(b.remindAt);
-                    return da - db;
-                });
-
+                const list = await processRemindersSnapshot(snapshot);
                 if (isMounted.current) {
                     setReminders(list);
                     setLoading(false);
@@ -105,42 +107,7 @@ export default function RemindersScreen({ navigation }) {
         try {
             const q = query(collection(db, 'reminders'), where('userId', '==', user.uid));
             const snapshot = await getDocs(q);
-            const list = [];
-            // Parallel fetch for speed
-            await Promise.all(
-                snapshot.docs.map(async docSnap => {
-                    const data = docSnap.data();
-                    let eventTitle = 'Event';
-                    let eventLocation = '';
-                    let bannerUrl = null;
-                    try {
-                        const eventDoc = await getDoc(doc(db, 'events', data.eventId));
-                        if (eventDoc.exists()) {
-                            const ed = eventDoc.data();
-                            eventTitle = ed.title;
-                            eventLocation = ed.location;
-                            bannerUrl = ed.bannerUrl;
-                        }
-                    } catch (e) {
-                        console.log(e);
-                    }
-
-                    list.push({
-                        id: docSnap.id,
-                        eventTitle,
-                        eventLocation,
-                        bannerUrl,
-                        ...data,
-                    });
-                }),
-            );
-
-            // Sort by remindAt
-            list.sort((a, b) => {
-                const da = a.remindAt?.toDate ? a.remindAt.toDate() : new Date(a.remindAt);
-                const db = b.remindAt?.toDate ? b.remindAt.toDate() : new Date(b.remindAt);
-                return da - db;
-            });
+            const list = await processRemindersSnapshot(snapshot);
 
             if (isMounted.current) {
                 setReminders(list);

--- a/app/src/screens/RemindersScreen.js
+++ b/app/src/screens/RemindersScreen.js
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import { collection, deleteDoc, doc, query, where, getDoc, onSnapshot } from 'firebase/firestore';
+import { collection, deleteDoc, doc, query, where, getDoc, getDocs, onSnapshot } from 'firebase/firestore';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import {
     ActivityIndicator,
@@ -98,11 +98,61 @@ export default function RemindersScreen({ navigation }) {
         return () => unsubscribe();
     }, [user]);
 
-    // Manual refresh is now less critical but we can keep it for network retry
-    const handleRefresh = () => {
-        // onSnapshot auto-reconnects, but if we want to force re-render or check connectivity
+    // Manual refresh allows the user to explicitly retry fetching data if network is unstable
+    const handleRefresh = async () => {
+        if (!user) return;
         setRefreshing(true);
-        setTimeout(() => setRefreshing(false), 1000);
+        try {
+            const q = query(collection(db, 'reminders'), where('userId', '==', user.uid));
+            const snapshot = await getDocs(q);
+            const list = [];
+            // Parallel fetch for speed
+            await Promise.all(
+                snapshot.docs.map(async docSnap => {
+                    const data = docSnap.data();
+                    let eventTitle = 'Event';
+                    let eventLocation = '';
+                    let bannerUrl = null;
+                    try {
+                        const eventDoc = await getDoc(doc(db, 'events', data.eventId));
+                        if (eventDoc.exists()) {
+                            const ed = eventDoc.data();
+                            eventTitle = ed.title;
+                            eventLocation = ed.location;
+                            bannerUrl = ed.bannerUrl;
+                        }
+                    } catch (e) {
+                        console.log(e);
+                    }
+
+                    list.push({
+                        id: docSnap.id,
+                        eventTitle,
+                        eventLocation,
+                        bannerUrl,
+                        ...data,
+                    });
+                }),
+            );
+
+            // Sort by remindAt
+            list.sort((a, b) => {
+                const da = a.remindAt?.toDate ? a.remindAt.toDate() : new Date(a.remindAt);
+                const db = b.remindAt?.toDate ? b.remindAt.toDate() : new Date(b.remindAt);
+                return da - db;
+            });
+
+            if (isMounted.current) {
+                setReminders(list);
+            }
+        } catch (error) {
+            console.error('Refresh error:', error);
+            Alert.alert('Error', 'Failed to refresh reminders.');
+        } finally {
+            if (isMounted.current) {
+                setRefreshing(false);
+            }
+        }
     };
 
     const handleDelete = async item => {


### PR DESCRIPTION
Fixes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state-update warnings and potential crashes when leaving the reminders screen during active operations.
  * Improved error handling with clearer user alerts on refresh failures.

* **Improvements**
  * Faster reminder refresh by loading related event data in parallel.
  * Reminders reliably display sorted by scheduled reminder time.
  * Manual refresh flow made more reliable and responsive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->