### PR TITLE
Add missing client-side authorization check to sendCertificates

### DIFF
--- a/app/src/screens/EventDetail.js
+++ b/app/src/screens/EventDetail.js
@@ -27,7 +27,6 @@ import {
     Text,
     TouchableOpacity,
     View,
-    Share,
 } from 'react-native';
 import FeedbackModal from '../components/FeedbackModal';
 import AppealModal from '../components/AppealModal';
@@ -437,29 +436,6 @@ export default function EventDetail({ route, navigation }) {
         if (url) Linking.openURL(url).catch(() => Alert.alert('Error', 'Invalid Link'));
     };
 
-    const handleExportReviews = async () => {
-        try {
-            const feedbackRef = collection(db, `events/${eventId}/feedback`);
-            const snapshot = await getDocs(feedbackRef);
-
-            if (snapshot.empty) {
-                Alert.alert('No Reviews', 'This event has no feedback yet.');
-                return;
-            }
-
-            let csv = 'User Name,Event Rating,Organizer Rating,Feedback,Date\n';
-            snapshot.forEach(doc => {
-                const d = doc.data();
-                const line = `\"${d.userName || 'Anonymous'}\",\"${d.eventRating || '-'}\",\"${d.clubRating || '-'}\",\"${(d.feedback || '').replace(/\"/g, '""')}\",${d.createdAt}\n`;
-                csv += line;
-            });
-
-            await Share.share({ message: csv, title: `Reviews - ${event.title}` });
-        } catch (error) {
-            console.error('Export Error: ', error);
-            Alert.alert('Error', 'Failed to export reviews.');
-        }
-    };
 
     const sendCertificates = async () => {
         if (!isOwner && user?.role !== 'admin') {

--- a/app/src/screens/EventDetail.js
+++ b/app/src/screens/EventDetail.js
@@ -462,6 +462,11 @@ export default function EventDetail({ route, navigation }) {
     };
 
     const sendCertificates = async () => {
+        if (!isOwner && user?.role !== 'admin') {
+            Alert.alert('Unauthorized', 'Only the event owner can send certificates.');
+            return;
+        }
+
         setSendingCertificates(true);
         try {
             // Fetch Participants


### PR DESCRIPTION
Fixes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Only event owners or admins can send certificates now; unauthorized users attempting this action will see an “Unauthorized” alert and the action is blocked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->