### PR TITLE
Fix Firestore rules ownership and profile update validation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,9 +2,12 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{userId} {
-      allow create: if request.auth != null && request.auth.uid == userId;
+      allow create: if request.auth != null && request.auth.uid == userId && !("role" in request.resource.data);
       allow read: if request.auth != null && request.auth.uid == userId;
-      allow update: if request.auth != null && (request.auth.uid == userId || request.auth.token.admin == true);
+      allow update: if request.auth != null && (
+        request.auth.token.admin == true || 
+        (request.auth.uid == userId && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role']))
+      );
     }
     match /clubs/{clubId} {
       allow read: if true;

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,7 +4,7 @@ service cloud.firestore {
     match /users/{userId} {
       allow create: if request.auth != null && request.auth.uid == userId;
       allow read: if request.auth != null && request.auth.uid == userId;
-      allow update: if request.auth.token.admin == true;
+      allow update: if request.auth != null && (request.auth.uid == userId || request.auth.token.admin == true);
     }
     match /clubs/{clubId} {
       allow read: if true;
@@ -13,8 +13,9 @@ service cloud.firestore {
     }
     match /events/{eventId} {
       allow read: if true;
-      allow create: if request.auth != null && (request.auth.token.admin == true || request.auth.token.club == true);
-      allow update, delete: if request.auth != null && (request.auth.token.admin == true || request.auth.uid == resource.data.ownerId);
+      allow create: if request.auth != null && (request.auth.token.admin == true || (request.auth.token.club == true && request.resource.data.ownerId == request.auth.uid));
+      allow update: if request.auth != null && (request.auth.token.admin == true || (request.auth.uid == resource.data.ownerId && request.resource.data.ownerId == resource.data.ownerId));
+      allow delete: if request.auth != null && (request.auth.token.admin == true || request.auth.uid == resource.data.ownerId);
     }
     match /reminders/{rid} {
       allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;


### PR DESCRIPTION

Closes https://github.com/roshankumar0036singh/Uni-Event/issues/196
 Pull Request: Fix Firestore Security Rules for Ownership Validation

## Description
This pull request addresses several critical security vulnerabilities and logic flaws in our `firestore.rules` related to the `events` and `users` collections.

### Fixes Implemented:
1. **Prevent Impersonation on Event Creation:**
   - **Before:** Any user with a `club` token could create an event, but there was no validation on the `ownerId` field. They could set it to any user's ID.
   - **After:** Enforced `request.resource.data.ownerId == request.auth.uid` for club users creating events. (Admins bypass this check).

2. **Prevent Unauthorized Ownership Transfer on Update:**
   - **Before:** During an event update, only the existing `ownerId` was checked (`request.auth.uid == resource.data.ownerId`). The rule did not prevent modifying the `ownerId` field, potentially allowing users to transfer ownership or lock themselves out.
   - **After:** Separated the `update` and `delete` rules. Added `request.resource.data.ownerId == resource.data.ownerId` on `update` to ensure the owner ID cannot be tampered with.

3. **Allow Users to Update Their Own Profiles:**
   - **Before:** The `/users/{userId}` update rule was restricted exclusively to admins (`request.auth.token.admin == true`).
   - **After:** Users can now update their own user documents (`request.auth.uid == userId`). Admins retain their update privileges.

## Files Modified
- `firestore.rules`

## Testing Steps
1. **User Profile Updates:** Ensure that a logged-in non-admin user can successfully update their own document in the `users` collection.
2. **Event Creation:** Test that a club user can only create an event where the `ownerId` matches their own UID. Attempting to create an event with another UID should fail.
3. **Event Updates:** Test that an event owner can update the event title/description, but if they attempt to change the `ownerId`, the update should fail.
4. **Admin Privileges:** Verify that admin users still retain the ability to update other users and bypass event ownership restrictions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users can now create profiles only without setting privileged fields, and cannot escalate their role during create or update.
  * Users can update their own profile (admins still retain full access).
  * Event creation, update, and deletion now require proper ownership or admin rights; event owner fields are validated to prevent hijacking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->