### PR TITLE
fix(auth): hide native password visibility icon on web and Android

### DIFF
--- a/app/src/screens/AuthScreen.js
+++ b/app/src/screens/AuthScreen.js
@@ -32,6 +32,7 @@ export default function AuthScreen() {
     const [isLogin, setIsLogin] = useState(true);
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
     const [name, setName] = useState('');
     const [loading, setLoading] = useState(false);
     const [passwordError, setPasswordError] = useState('');
@@ -47,6 +48,28 @@ export default function AuthScreen() {
                 ? window.location.origin || process.env.EXPO_PUBLIC_REDIRECT_URI
                 : process.env.EXPO_PUBLIC_REDIRECT_URI || makeRedirectUri({ useProxy: true }),
     });
+
+    // Suppress the native browser password-reveal eye icon on web
+    useEffect(() => {
+        if (Platform.OS === 'web') {
+            const style = document.createElement('style');
+            style.id = 'hide-password-reveal';
+            style.textContent = `
+                input[type="password"]::-ms-reveal,
+                input[type="password"]::-ms-clear,
+                input[type="password"]::-webkit-credentials-auto-fill-button,
+                input[type="password"]::-webkit-textfield-decoration-container,
+                input[type="password"]::-webkit-password-reveal-button {
+                    display: none !important;
+                }
+            `;
+            document.head.appendChild(style);
+            return () => {
+                const existing = document.getElementById('hide-password-reveal');
+                if (existing) existing.remove();
+            };
+        }
+    }, []);
 
     useEffect(() => {
         setPasswordError('');
@@ -280,7 +303,7 @@ export default function AuthScreen() {
                             <TextInput
                                 style={[
                                     styles.input,
-                                    { color: theme.colors.text, backgroundColor: 'transparent' },
+                                    { color: theme.colors.text, backgroundColor: 'transparent', paddingRight: 40 },
                                 ]}
                                 placeholder="Password"
                                 placeholderTextColor={theme.colors.textSecondary}
@@ -289,8 +312,32 @@ export default function AuthScreen() {
                                     setPassword(text);
                                     if (passwordError) setPasswordError('');
                                 }}
-                                secureTextEntry
+                                secureTextEntry={!showPassword}
+                                autoComplete="new-password"
+                                importantForAutofill="no"
+                                autoCorrect={false}
+                                textContentType="none"
                             />
+                            <TouchableOpacity
+                                onPress={() => setShowPassword(!showPassword)}
+                                style={{
+                                    position: 'absolute',
+                                    right: 10,
+                                    top: 12,
+                                    backgroundColor: theme.colors.surface,
+                                    borderRadius: 12,
+                                    padding: 4,
+                                    zIndex: 10,
+                                }}
+                                accessibilityRole="button"
+                                accessibilityLabel={showPassword ? "Hide password" : "Show password"}
+                            >
+                                <Ionicons
+                                    name={showPassword ? "eye-outline" : "eye-off-outline"}
+                                    size={20}
+                                    color={theme.colors.textSecondary}
+                                />
+                            </TouchableOpacity>
                         </View>
                         {!isLogin && passwordError ? (
                             <Text style={styles.errorText}>{passwordError}</Text>

--- a/app/src/screens/AuthScreen.js
+++ b/app/src/screens/AuthScreen.js
@@ -50,26 +50,31 @@ export default function AuthScreen() {
     });
 
     // Suppress the native browser password-reveal eye icon on web
-    useEffect(() => {
-        if (Platform.OS === 'web') {
-            const style = document.createElement('style');
-            style.id = 'hide-password-reveal';
-            style.textContent = `
-                input[type="password"]::-ms-reveal,
-                input[type="password"]::-ms-clear,
-                input[type="password"]::-webkit-credentials-auto-fill-button,
-                input[type="password"]::-webkit-textfield-decoration-container,
-                input[type="password"]::-webkit-password-reveal-button {
-                    display: none !important;
-                }
-            `;
-            document.head.appendChild(style);
-            return () => {
-                const existing = document.getElementById('hide-password-reveal');
-                if (existing) existing.remove();
-            };
+useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    // Avoid duplicate creation and track ownership
+    if (document.getElementById('hide-password-reveal')) return;
+    const style = document.createElement('style');
+    style.id = 'hide-password-reveal';
+    style.textContent = `
+        input[type="password"]::-ms-reveal,
+        input[type="password"]::-ms-clear,
+        input[type="password"]::-webkit-credentials-auto-fill-button,
+        input[type="password"]::-webkit-textfield-decoration-container,
+        input[type="password"]::-webkit-password-reveal-button {
+            display: none !important;
+        }`;
+    document.head.appendChild(style);
+    // Flag indicating we created the style element
+    const createdStyle = true;
+    // Cleanup only if we created the style element
+    return () => {
+        if (createdStyle) {
+            const existing = document.getElementById('hide-password-reveal');
+            if (existing) existing.remove();
         }
-    }, []);
+    };
+}, []);
 
     useEffect(() => {
         setPasswordError('');
@@ -313,7 +318,7 @@ export default function AuthScreen() {
                                     if (passwordError) setPasswordError('');
                                 }}
                                 secureTextEntry={!showPassword}
-                                autoComplete="new-password"
+                                autoComplete={isLogin ? "current-password" : "new-password"}
                                 importantForAutofill="no"
                                 autoCorrect={false}
                                 textContentType="none"
@@ -333,7 +338,7 @@ export default function AuthScreen() {
                                 accessibilityLabel={showPassword ? "Hide password" : "Show password"}
                             >
                                 <Ionicons
-                                    name={showPassword ? "eye-outline" : "eye-off-outline"}
+                                    name={showPassword ? "eye-off-outline" : "eye-outline"}
                                     size={20}
                                     color={theme.colors.textSecondary}
                                 />


### PR DESCRIPTION
# Description

Implemented a reliable password‑visibility toggle for the authentication screen and fully suppressed the native eye‑icon that appears on Android devices and web browsers.

Added autoComplete="new-password", importantForAutofill="no" and textContentType="none" to the TextInput to stop Android’s system‑provided eye icon.
Injected CSS via a useEffect (only on web) that hides the browser‑provided password‑reveal button (::-ms-reveal, ::-webkit‑password‑reveal-button, etc.).
Created a styled TouchableOpacity with a custom Ionicons eye/eye‑off icon, positioned with a higher zIndex to stay on top of any system UI.
Added explanatory comments for future maintainers.

Fixes #201 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run the dev server: npm run web.
Open http://localhost:19006/ (or the next free port).
Focus the password field and type any character.
Result: Only the custom white eye icon appears; the native black/blue eye icon is absent.
Click the custom eye icon – password visibility toggles correctly.
Clear the field and type again – the native eye icon does not re‑appear.

 Test A – Manual UI verification on web (Chrome/Edge).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<img width="684" height="93" alt="image" src="https://github.com/user-attachments/assets/48a7f5f0-4980-4627-89d6-e232e391ffa2" />

<img width="684" height="92" alt="image" src="https://github.com/user-attachments/assets/0c8b4310-3d65-4068-b3cf-0ac4ad73495e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a password visibility toggle (eye icon) on the authentication screen to show or hide the password field.

* **Improvements**
  * Updated password input behavior and styling for better spacing and autofill/autocorrect handling.
  * Improved web experience by suppressing the browser’s native password reveal/clear UI for a consistent look.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->