### PR TITLE
fix: resolve non-atomic database writes during registration and check-in (#215)

### DIFF
--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -1,4 +1,4 @@
-import { doc, getDoc, serverTimestamp, increment, writeBatch } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, increment, runTransaction } from 'firebase/firestore';
 import { db } from './firebaseConfig';
 
 /**
@@ -75,51 +75,58 @@ export const checkInAttendee = async (ticketData, eventId, organizerId, organize
         const ticketId = ticketData.id;
         const userId = ticketData.userId;
 
-        const batch = writeBatch(db);
+        await runTransaction(db, async transaction => {
+            const ticketRef = doc(db, 'tickets', ticketId);
+            const ticketSnap = await transaction.get(ticketRef);
 
-        // Create check-in record
-        const checkInRef = doc(db, 'events', eventId, 'checkIns', userId);
-        batch.set(checkInRef, {
-            userId,
-            userName: ticketData.userName || 'Guest',
-            userEmail: ticketData.userEmail || '',
-            userYear: ticketData.userYear || 'N/A',
-            userBranch: ticketData.userBranch || 'N/A',
-            ticketId,
-            checkedInAt: serverTimestamp(),
-            checkedInBy: organizerId,
-            checkedInByName: organizerName,
-            status: 'checked-in',
+            if (!ticketSnap.exists()) {
+                throw new Error('Ticket not found');
+            }
+
+            const freshTicket = ticketSnap.data();
+            if (freshTicket.eventId !== eventId || freshTicket.status !== 'paid') {
+                throw new Error('Ticket is no longer eligible for check-in');
+            }
+            if (freshTicket.checkInStatus === 'checked-in') {
+                throw new Error('Ticket already checked in');
+            }
+
+            const checkInRef = doc(db, 'events', eventId, 'checkIns', userId);
+            const eventRef = doc(db, 'events', eventId);
+            const userRef = doc(db, 'users', userId);
+
+            transaction.set(checkInRef, {
+                userId,
+                userName: ticketData.userName || 'Guest',
+                userEmail: ticketData.userEmail || '',
+                userYear: ticketData.userYear || 'N/A',
+                userBranch: ticketData.userBranch || 'N/A',
+                ticketId,
+                checkedInAt: serverTimestamp(),
+                checkedInBy: organizerId,
+                checkedInByName: organizerName,
+                status: 'checked-in',
+            });
+
+            transaction.update(ticketRef, {
+                checkInStatus: 'checked-in',
+                checkedInAt: serverTimestamp(),
+                checkedInBy: organizerId,
+            });
+
+            transaction.update(eventRef, {
+                'stats.totalCheckedIn': increment(1),
+                'stats.lastCheckInAt': serverTimestamp(),
+            });
+
+            transaction.set(
+                userRef,
+                {
+                    lastActive: serverTimestamp(),
+                },
+                { merge: true },
+            );
         });
-
-        // Update ticket status
-        const ticketRef = doc(db, 'tickets', ticketId);
-        batch.update(ticketRef, {
-            checkInStatus: 'checked-in',
-            checkedInAt: serverTimestamp(),
-            checkedInBy: organizerId,
-        });
-
-        // Update event stats
-        const eventRef = doc(db, 'events', eventId);
-
-        batch.update(eventRef, {
-            'stats.totalCheckedIn': increment(1),
-            'stats.lastCheckInAt': serverTimestamp(),
-        });
-
-        // Update user activity
-        const userRef = doc(db, 'users', userId);
-
-        batch.set(
-            userRef,
-            {
-                lastActive: serverTimestamp(),
-            },
-            { merge: true },
-        );
-
-        await batch.commit();
 
         return {
             success: true,

--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -1,4 +1,4 @@
-import { doc, getDoc, setDoc, serverTimestamp, updateDoc, increment } from 'firebase/firestore';
+import { doc, getDoc, setDoc, serverTimestamp, updateDoc, increment, writeBatch } from 'firebase/firestore';
 import { db } from './firebaseConfig';
 
 /**
@@ -75,9 +75,11 @@ export const checkInAttendee = async (ticketData, eventId, organizerId, organize
         const ticketId = ticketData.id;
         const userId = ticketData.userId;
 
+        const batch = writeBatch(db);
+
         // Create check-in record
         const checkInRef = doc(db, 'events', eventId, 'checkIns', userId);
-        await setDoc(checkInRef, {
+        batch.set(checkInRef, {
             userId,
             userName: ticketData.userName || 'Guest',
             userEmail: ticketData.userEmail || '',
@@ -92,7 +94,7 @@ export const checkInAttendee = async (ticketData, eventId, organizerId, organize
 
         // Update ticket status
         const ticketRef = doc(db, 'tickets', ticketId);
-        await updateDoc(ticketRef, {
+        batch.update(ticketRef, {
             checkInStatus: 'checked-in',
             checkedInAt: serverTimestamp(),
             checkedInBy: organizerId,
@@ -101,7 +103,7 @@ export const checkInAttendee = async (ticketData, eventId, organizerId, organize
         // Update event stats
         const eventRef = doc(db, 'events', eventId);
 
-        await updateDoc(eventRef, {
+        batch.update(eventRef, {
             'stats.totalCheckedIn': increment(1),
             'stats.lastCheckInAt': serverTimestamp(),
         });
@@ -109,13 +111,15 @@ export const checkInAttendee = async (ticketData, eventId, organizerId, organize
         // Update user activity
         const userRef = doc(db, 'users', userId);
 
-        await setDoc(
+        batch.set(
             userRef,
             {
                 lastActive: serverTimestamp(),
             },
             { merge: true },
         );
+
+        await batch.commit();
 
         return {
             success: true,

--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -1,4 +1,4 @@
-import { doc, getDoc, setDoc, serverTimestamp, updateDoc, increment, writeBatch } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, increment, writeBatch } from 'firebase/firestore';
 import { db } from './firebaseConfig';
 
 /**

--- a/app/src/screens/EventRegistrationFormScreen.js
+++ b/app/src/screens/EventRegistrationFormScreen.js
@@ -23,6 +23,7 @@ import {
     increment,
     getDoc,
     arrayUnion,
+    writeBatch,
 } from 'firebase/firestore';
 import { db } from '../lib/firebaseConfig';
 import { useAuth } from '../lib/AuthContext';
@@ -87,8 +88,11 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
             const userDoc = await getDoc(doc(db, 'users', user.uid));
             const userData = userDoc.exists() ? userDoc.data() : {};
 
+            const batch = writeBatch(db);
+
             // B. Save Custom Form Responses
-            await addDoc(collection(db, 'registrations'), {
+            const newRegistrationRef = doc(collection(db, 'registrations'));
+            batch.set(newRegistrationRef, {
                 eventId: event.id,
                 eventId_userId: `${event.id}_${user.uid}`,
                 userId: user.uid,
@@ -101,7 +105,8 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
             });
 
             // C. Add to Event Participants
-            await setDoc(doc(db, 'events', event.id, 'participants', user.uid), {
+            const participantRef = doc(db, 'events', event.id, 'participants', user.uid);
+            batch.set(participantRef, {
                 userId: user.uid,
                 name: user.displayName || 'Anonymous',
                 email: user.email,
@@ -111,7 +116,8 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
             });
 
             // D. Add to User's Participating List
-            await setDoc(doc(db, 'users', user.uid, 'participating', event.id), {
+            const participatingRef = doc(db, 'users', user.uid, 'participating', event.id);
+            batch.set(participatingRef, {
                 eventId: event.id,
                 joinedAt: new Date().toISOString(),
             });
@@ -122,7 +128,10 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
             if (earlyBird) {
                 userUpdate.badges = arrayUnion(`early_bird_${event.id}`);
             }
-            await updateDoc(doc(db, 'users', user.uid), userUpdate);
+            const userRef = doc(db, 'users', user.uid);
+            batch.update(userRef, userUpdate);
+
+            await batch.commit();
 
             // F. Schedule Reminder
             await scheduleEventReminder(event);

--- a/app/src/screens/EventRegistrationFormScreen.js
+++ b/app/src/screens/EventRegistrationFormScreen.js
@@ -15,11 +15,8 @@ import ConfettiCannon from 'react-native-confetti-cannon';
 import { useTheme } from '../lib/ThemeContext';
 import PremiumInput from '../components/PremiumInput';
 import {
-    addDoc,
     collection,
-    setDoc,
     doc,
-    updateDoc,
     increment,
     getDoc,
     arrayUnion,


### PR DESCRIPTION
## Description

Fixes #215

This PR resolves a critical data integrity flaw where sequential document writes during event registration and check-ins could result in partial updates (corrupted data) if the network dropped or the app crashed mid-execution.

## Changes Made
- **`app/src/lib/checkInService.js`:** Wrapped the sequential `setDoc` and `updateDoc` calls inside `checkInAttendee` into a single, atomic `writeBatch` transaction. Now, creating the check-in record, updating the ticket status, incrementing event stats, and updating user activity will either entirely succeed together or fail safely without corrupting the state.
- **`app/src/screens/EventRegistrationFormScreen.js`:** Similarly updated the `handleSubmit` logic. Form response saving, event participant additions, user participating list updates, and points/badge awards are now successfully grouped into an atomic `writeBatch` commit. Replaced the `addDoc` call with generating a standard ref (`doc(collection(db, 'registrations'))`) and using `batch.set()` to properly include the dynamic ID inside the transaction.

## GSSoC 2026
This PR is submitted as part of GSSoC 2026. Closes #215.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made check-in operations atomic and more reliable to prevent duplicate or invalid check-ins.
  * Grouped registration writes into a single commit for consistent, all-or-nothing event sign-ups.

These behind-the-scenes changes improve reliability and consistency of check-in and registration flows without altering user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->