### PR TITLE
feat: offline QR check-in queue with sync (fixes #221)

### DIFF
--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -1,7 +1,6 @@
-import { doc, getDoc, serverTimestamp, increment, runTransaction } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, increment, runTransaction, setDoc, updateDoc } from 'firebase/firestore';
 import { db } from './firebaseConfig';
-
-/**
+import AsyncStorage from '@react-native-async-storage/async-storage';
  * Validate a ticket for check-in
  */
 export const validateTicket = async (ticketId, eventId) => {
@@ -205,5 +204,92 @@ export const parseQRCode = qrData => {
             valid: false,
             error: 'Unable to parse QR code',
         };
+    }
+};
+
+const getOfflineQueueKey = (eventId) => `@offline_checkins_${eventId}`;
+
+export const queueOfflineCheckIn = async (eventId, checkInData) => {
+    try {
+        const key = getOfflineQueueKey(eventId);
+        const existingQueueStr = await AsyncStorage.getItem(key);
+        const queue = existingQueueStr ? JSON.parse(existingQueueStr) : [];
+        
+        if (!queue.find(item => item.userId === checkInData.userId)) {
+            queue.push({
+                ...checkInData,
+                queuedAt: new Date().toISOString()
+            });
+            await AsyncStorage.setItem(key, JSON.stringify(queue));
+        }
+        return true;
+    } catch (e) {
+        console.error('Failed to queue offline check-in', e);
+        return false;
+    }
+};
+
+export const getOfflineCheckInCount = async (eventId) => {
+    try {
+        const key = getOfflineQueueKey(eventId);
+        const existingQueueStr = await AsyncStorage.getItem(key);
+        if (!existingQueueStr) return 0;
+        const queue = JSON.parse(existingQueueStr);
+        return queue.length;
+    } catch (e) {
+        return 0;
+    }
+};
+
+export const syncOfflineCheckIns = async (eventId, organizerId) => {
+    try {
+        const key = getOfflineQueueKey(eventId);
+        const existingQueueStr = await AsyncStorage.getItem(key);
+        if (!existingQueueStr) return { success: true, syncedCount: 0 };
+        
+        const queue = JSON.parse(existingQueueStr);
+        if (queue.length === 0) return { success: true, syncedCount: 0 };
+        
+        let syncedCount = 0;
+        let failedQueue = [];
+
+        for (const item of queue) {
+            try {
+                const checkInRef = doc(db, 'events', eventId, 'checkIns', item.userId);
+                
+                const checkInSnap = await getDoc(checkInRef);
+                if (!checkInSnap.exists()) {
+                    await setDoc(checkInRef, {
+                        userId: item.userId,
+                        userName: item.userName || 'Guest',
+                        userBranch: item.userBranch || 'N/A',
+                        userYear: item.userYear || 'N/A',
+                        checkedInAt: serverTimestamp(),
+                        checkedBy: organizerId,
+                        ticketId: item.ticketId || null,
+                        syncedOffline: true
+                    });
+                    
+                    const registrationRef = doc(db, 'events', eventId, 'registrations', item.userId);
+                    await updateDoc(registrationRef, { status: 'attended' }).catch(() => {});
+                }
+                
+                syncedCount++;
+            } catch (err) {
+                console.error('Failed to sync item', err);
+                failedQueue.push(item);
+            }
+        }
+
+        if (failedQueue.length > 0) {
+            await AsyncStorage.setItem(key, JSON.stringify(failedQueue));
+            return { success: false, syncedCount, remainingCount: failedQueue.length };
+        } else {
+            await AsyncStorage.removeItem(key);
+            return { success: true, syncedCount };
+        }
+    } catch (e) {
+        console.error('Sync error', e);
+        return { success: false, syncedCount: 0, error: e };
     }
 };

--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -269,11 +269,14 @@ export const syncOfflineCheckIns = async (eventId, organizerId) => {
                     await setDoc(checkInRef, {
                         userId: item.userId,
                         userName: item.userName || 'Guest',
+                        userEmail: item.userEmail || '',
                         userBranch: item.userBranch || 'N/A',
                         userYear: item.userYear || 'N/A',
                         checkedInAt: offlineCheckedInAt,
                         checkedInBy: organizerId,
+                        checkedInByName: item.organizerName || organizerId,
                         ticketId: item.ticketId || null,
+                        status: 'checked-in',
                         syncedOffline: true,
                     });
 

--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -1,4 +1,4 @@
-import { doc, getDoc, serverTimestamp, increment, runTransaction, setDoc, updateDoc } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, increment, runTransaction, setDoc, updateDoc, Timestamp } from 'firebase/firestore';
 import { db } from './firebaseConfig';
 import AsyncStorage from '@react-native-async-storage/async-storage';
  * Validate a ticket for check-in
@@ -256,20 +256,40 @@ export const syncOfflineCheckIns = async (eventId, organizerId) => {
         for (const item of queue) {
             try {
                 const checkInRef = doc(db, 'events', eventId, 'checkIns', item.userId);
-                
+
                 const checkInSnap = await getDoc(checkInRef);
                 if (!checkInSnap.exists()) {
+                    // Preserve original scan time; fall back to server time if missing
+                    const offlineCheckedInAt = item.queuedAt
+                        ? Timestamp.fromDate(new Date(item.queuedAt))
+                        : serverTimestamp();
+
                     await setDoc(checkInRef, {
                         userId: item.userId,
                         userName: item.userName || 'Guest',
                         userBranch: item.userBranch || 'N/A',
                         userYear: item.userYear || 'N/A',
-                        checkedInAt: serverTimestamp(),
-                        checkedBy: organizerId,
+                        checkedInAt: offlineCheckedInAt,
+                        checkedInBy: organizerId,
                         ticketId: item.ticketId || null,
-                        syncedOffline: true
+                        syncedOffline: true,
                     });
-                    
+
+                    // Mark the ticket as checked-in so validateTicket sees it used
+                    if (item.ticketId) {
+                        await updateDoc(doc(db, 'tickets', item.ticketId), {
+                            checkInStatus: 'checked-in',
+                            checkedInAt: offlineCheckedInAt,
+                            checkedInBy: organizerId,
+                        }).catch(() => {});
+                    }
+
+                    // Increment event stats to keep dashboard accurate
+                    await updateDoc(doc(db, 'events', eventId), {
+                        'stats.totalCheckedIn': increment(1),
+                        'stats.lastCheckInAt': serverTimestamp(),
+                    }).catch(() => {});
+
                     const registrationRef = doc(db, 'events', eventId, 'registrations', item.userId);
                     await updateDoc(registrationRef, { status: 'attended' }).catch(() => {});
                 }

--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -217,7 +217,7 @@ export const queueOfflineCheckIn = async (eventId, checkInData) => {
         const existingQueueStr = await AsyncStorage.getItem(key);
         const queue = existingQueueStr ? JSON.parse(existingQueueStr) : [];
         
-        if (!queue.find(item => item.userId === checkInData.userId)) {
+        if (!queue.some(item => item.userId === checkInData.userId)) {
             queue.push({
                 ...checkInData,
                 queuedAt: new Date().toISOString()
@@ -238,8 +238,49 @@ export const getOfflineCheckInCount = async (eventId) => {
         if (!existingQueueStr) return 0;
         const queue = JSON.parse(existingQueueStr);
         return queue.length;
-    } catch (e) {
+    } catch (err) {
+        console.error('Failed to get offline count:', err);
         return 0;
+    }
+};
+
+const syncOfflineCheckInItem = async (item, eventId, organizerId) => {
+    const checkInRef = doc(db, 'events', eventId, 'checkIns', item.userId);
+    const checkInSnap = await getDoc(checkInRef);
+    if (!checkInSnap.exists()) {
+        const offlineCheckedInAt = item.queuedAt
+            ? Timestamp.fromDate(new Date(item.queuedAt))
+            : serverTimestamp();
+
+        await setDoc(checkInRef, {
+            userId: item.userId,
+            userName: item.userName || 'Guest',
+            userEmail: item.userEmail || '',
+            userBranch: item.userBranch || 'N/A',
+            userYear: item.userYear || 'N/A',
+            checkedInAt: offlineCheckedInAt,
+            checkedInBy: organizerId,
+            checkedInByName: item.organizerName || organizerId,
+            ticketId: item.ticketId || null,
+            status: 'checked-in',
+            syncedOffline: true,
+        });
+
+        if (item.ticketId) {
+            await updateDoc(doc(db, 'tickets', item.ticketId), {
+                checkInStatus: 'checked-in',
+                checkedInAt: offlineCheckedInAt,
+                checkedInBy: organizerId,
+            }).catch(() => {});
+        }
+
+        await updateDoc(doc(db, 'events', eventId), {
+            'stats.totalCheckedIn': increment(1),
+            'stats.lastCheckInAt': serverTimestamp(),
+        }).catch(() => {});
+
+        const registrationRef = doc(db, 'events', eventId, 'registrations', item.userId);
+        await updateDoc(registrationRef, { status: 'attended' }).catch(() => {});
     }
 };
 
@@ -257,48 +298,7 @@ export const syncOfflineCheckIns = async (eventId, organizerId) => {
 
         for (const item of queue) {
             try {
-                const checkInRef = doc(db, 'events', eventId, 'checkIns', item.userId);
-
-                const checkInSnap = await getDoc(checkInRef);
-                if (!checkInSnap.exists()) {
-                    // Preserve original scan time; fall back to server time if missing
-                    const offlineCheckedInAt = item.queuedAt
-                        ? Timestamp.fromDate(new Date(item.queuedAt))
-                        : serverTimestamp();
-
-                    await setDoc(checkInRef, {
-                        userId: item.userId,
-                        userName: item.userName || 'Guest',
-                        userEmail: item.userEmail || '',
-                        userBranch: item.userBranch || 'N/A',
-                        userYear: item.userYear || 'N/A',
-                        checkedInAt: offlineCheckedInAt,
-                        checkedInBy: organizerId,
-                        checkedInByName: item.organizerName || organizerId,
-                        ticketId: item.ticketId || null,
-                        status: 'checked-in',
-                        syncedOffline: true,
-                    });
-
-                    // Mark the ticket as checked-in so validateTicket sees it used
-                    if (item.ticketId) {
-                        await updateDoc(doc(db, 'tickets', item.ticketId), {
-                            checkInStatus: 'checked-in',
-                            checkedInAt: offlineCheckedInAt,
-                            checkedInBy: organizerId,
-                        }).catch(() => {});
-                    }
-
-                    // Increment event stats to keep dashboard accurate
-                    await updateDoc(doc(db, 'events', eventId), {
-                        'stats.totalCheckedIn': increment(1),
-                        'stats.lastCheckInAt': serverTimestamp(),
-                    }).catch(() => {});
-
-                    const registrationRef = doc(db, 'events', eventId, 'registrations', item.userId);
-                    await updateDoc(registrationRef, { status: 'attended' }).catch(() => {});
-                }
-                
+                await syncOfflineCheckInItem(item, eventId, organizerId);
                 syncedCount++;
             } catch (err) {
                 console.error('Failed to sync item', err);

--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -1,6 +1,8 @@
 import { doc, getDoc, serverTimestamp, increment, runTransaction, setDoc, updateDoc, Timestamp } from 'firebase/firestore';
 import { db } from './firebaseConfig';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
  * Validate a ticket for check-in
  */
 export const validateTicket = async (ticketId, eventId) => {

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -185,6 +185,7 @@ export default function AttendanceDashboard({ route, navigation }) {
                 Alert.alert('Sync Failed', `Could not sync offline check-ins: ${msg}`);
             }
         } catch (error) {
+            console.error('Failed to sync offline check-ins', error);
             Alert.alert('Error', 'Failed to sync offline check-ins.');
         }
         const count = await getOfflineCheckInCount(eventId);

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -11,7 +11,9 @@ import {
     where,
     updateDoc,
 } from 'firebase/firestore';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { getOfflineCheckInCount, syncOfflineCheckIns } from '../lib/checkInService';
 import {
     ActivityIndicator,
     Alert,
@@ -45,6 +47,12 @@ export default function AttendanceDashboard({ route, navigation }) {
     const [departmentStats, setDepartmentStats] = useState({});
     const [yearStats, setYearStats] = useState({});
     const [eventData, setEventData] = useState(null);
+
+    const { user } = useAuth();
+
+    // Offline Sync State
+    const [pendingOfflineCount, setPendingOfflineCount] = useState(0);
+    const [syncingOffline, setSyncingOffline] = useState(false);
 
     // Announcement State
     const [announcementModalVisible, setAnnouncementModalVisible] = useState(false);
@@ -152,6 +160,29 @@ export default function AttendanceDashboard({ route, navigation }) {
             if (snap.exists()) setEventData(snap.data());
         });
     }, [eventId]);
+
+    useFocusEffect(
+        useCallback(() => {
+            getOfflineCheckInCount(eventId).then(count => setPendingOfflineCount(count));
+        }, [eventId])
+    );
+
+    const handleSyncOffline = async () => {
+        setSyncingOffline(true);
+        try {
+            const result = await syncOfflineCheckIns(eventId, user?.uid || 'Unknown Organizer');
+            if (result.success) {
+                Alert.alert('Success', `Synced ${result.syncedCount} check-ins.`);
+            } else {
+                Alert.alert('Partial Sync', `Synced ${result.syncedCount} check-ins. ${result.remainingCount} remaining.`);
+            }
+        } catch (error) {
+            Alert.alert('Error', 'Failed to sync offline check-ins.');
+        }
+        const count = await getOfflineCheckInCount(eventId);
+        setPendingOfflineCount(count);
+        setSyncingOffline(false);
+    };
 
     // Live Participant Count
     const [totalRegistrations, setTotalRegistrations] = useState(0);
@@ -447,6 +478,17 @@ export default function AttendanceDashboard({ route, navigation }) {
             </View>
 
             <ScrollView showsVerticalScrollIndicator={false}>
+                {pendingOfflineCount > 0 && (
+                    <View style={[styles.offlineBanner, { backgroundColor: theme.colors.warning + '20', borderColor: theme.colors.warning }]}>
+                        <View style={{ flex: 1 }}>
+                            <Text style={[styles.offlineBannerTitle, { color: theme.colors.text }]}>Offline Sync Pending</Text>
+                            <Text style={[styles.offlineBannerText, { color: theme.colors.textSecondary }]}>{pendingOfflineCount} check-ins waiting for network</Text>
+                        </View>
+                        <TouchableOpacity style={[styles.syncBtn, { backgroundColor: theme.colors.warning }]} onPress={handleSyncOffline} disabled={syncingOffline}>
+                            {syncingOffline ? <ActivityIndicator size="small" color="#fff" /> : <Text style={styles.syncBtnText}>Sync Now</Text>}
+                        </TouchableOpacity>
+                    </View>
+                )}
                 <View style={styles.statsContainer}>
                     {/* Updated Stat Cards to use Primary Theme */}
                     <StatCard
@@ -1174,6 +1216,32 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
     },
     modalButtonText: { fontSize: 15, fontWeight: '700' },
+    offlineBanner: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginHorizontal: 20,
+        marginTop: 20,
+        padding: 15,
+        borderRadius: 12,
+        borderWidth: 1,
+    },
+    offlineBannerTitle: {
+        fontSize: 16,
+        fontWeight: 'bold',
+        marginBottom: 4,
+    },
+    offlineBannerText: {
+        fontSize: 13,
+    },
+    syncBtn: {
+        paddingHorizontal: 16,
+        paddingVertical: 8,
+        borderRadius: 20,
+    },
+    syncBtnText: {
+        color: '#fff',
+        fontWeight: 'bold',
+    },
 });
 
 AttendanceDashboard.propTypes = {

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -173,8 +173,16 @@ export default function AttendanceDashboard({ route, navigation }) {
             const result = await syncOfflineCheckIns(eventId, user?.uid || 'Unknown Organizer');
             if (result.success) {
                 Alert.alert('Success', `Synced ${result.syncedCount} check-ins.`);
+            } else if (typeof result.remainingCount === 'number') {
+                Alert.alert(
+                    'Partial Sync',
+                    `Synced ${result.syncedCount} check-ins. ${result.remainingCount} still pending.`,
+                );
             } else {
-                Alert.alert('Partial Sync', `Synced ${result.syncedCount} check-ins. ${result.remainingCount} remaining.`);
+                // Fatal error returned from syncOfflineCheckIns
+                const msg = result.error?.message || String(result.error) || 'Unknown error';
+                console.error('Offline sync fatal error:', result.error);
+                Alert.alert('Sync Failed', `Could not sync offline check-ins: ${msg}`);
             }
         } catch (error) {
             Alert.alert('Error', 'Failed to sync offline check-ins.');

--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -5,7 +5,7 @@ import { Dimensions, Platform, StyleSheet, Text, TouchableOpacity, View } from '
 import ScreenWrapper from '../components/ScreenWrapper';
 import WebQRScanner from '../components/WebQRScanner';
 import { useAuth } from '../lib/AuthContext';
-import { queueOfflineCheckIn, checkInAttendee, validateTicket } from '../lib/checkInService';
+import { queueOfflineCheckIn, checkInAttendee } from '../lib/checkInService';
 import { useTheme } from '../lib/ThemeContext';
 import PropTypes from 'prop-types';
 
@@ -77,6 +77,7 @@ export default function QRScannerScreen({ navigation, route }) {
                     const queued = await queueOfflineCheckIn(eventId, {
                         userId: scannedUserId,
                         userName: ticketData?.attendeeName || 'Guest',
+                        userEmail: ticketData?.attendeeEmail || '',
                         userBranch: ticketData?.branch || 'N/A',
                         userYear: ticketData?.year || 'N/A',
                         ticketId: ticketData?.ticketId || null,
@@ -130,6 +131,7 @@ export default function QRScannerScreen({ navigation, route }) {
                     const queued = await queueOfflineCheckIn(eventId, {
                         userId: scannedUserId,
                         userName: userData.name || ticketData?.attendeeName || 'Guest',
+                        userEmail: userData.email || ticketData?.attendeeEmail || '',
                         userBranch: userData.branch || ticketData?.branch || 'N/A',
                         userYear: userData.year || ticketData?.year || 'N/A',
                         ticketId: ticketData?.ticketId || null,

--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -1,12 +1,13 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Camera } from 'expo-camera';
-import { addDoc, collection, doc, getDoc, serverTimestamp, updateDoc } from 'firebase/firestore';
+import { addDoc, collection, doc, getDoc, serverTimestamp, updateDoc, setDoc } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import ScreenWrapper from '../components/ScreenWrapper';
 import WebQRScanner from '../components/WebQRScanner';
 import { useAuth } from '../lib/AuthContext';
 import { db } from '../lib/firebaseConfig';
+import { queueOfflineCheckIn } from '../lib/checkInService';
 import { useTheme } from '../lib/ThemeContext';
 import PropTypes from 'prop-types';
 
@@ -63,40 +64,80 @@ export default function QRScannerScreen({ navigation, route }) {
             console.log(`Scanned user: ${scannedUserId} for event: ${eventId}`);
 
             // 1. Verify User
-            const userRef = doc(db, 'users', scannedUserId);
-            const userSnap = await getDoc(userRef);
+            let userSnap;
+            try {
+                const userRef = doc(db, 'users', scannedUserId);
+                userSnap = await getDoc(userRef);
 
-            if (!userSnap.exists()) {
-                setScanResult({ status: 'error', message: 'Invalid User QR Code' });
-                return;
+                if (!userSnap.exists()) {
+                    setScanResult({ status: 'error', message: 'Invalid User QR Code' });
+                    return;
+                }
+            } catch (err) {
+                if (err.code === 'unavailable' || err.message?.includes('offline') || err.message?.includes('network')) {
+                    await queueOfflineCheckIn(eventId, {
+                        userId: scannedUserId,
+                        userName: ticketData?.attendeeName || 'Guest',
+                        userBranch: ticketData?.branch || 'N/A',
+                        userYear: ticketData?.year || 'N/A',
+                        ticketId: ticketData?.ticketId || null
+                    });
+                    
+                    setScanResult({
+                        status: 'success',
+                        message: `Queued offline check-in for ${ticketData?.attendeeName || 'Guest'}.`,
+                        user: { name: ticketData?.attendeeName || 'Guest' },
+                    });
+                    return;
+                }
+                throw err;
             }
 
             const userData = userSnap.data();
 
             // 2. CheckIn Logic
-            const checkInRef = collection(db, 'events', eventId, 'checkIns');
-            await addDoc(checkInRef, {
-                userId: scannedUserId,
-                userName: userData.name || ticketData?.attendeeName,
-                userBranch: userData.branch || ticketData?.branch,
-                userYear: userData.year || ticketData?.year,
-                checkedInAt: serverTimestamp(),
-                checkedBy: user.uid,
-                ticketId: ticketData?.ticketId || null,
-            });
+            try {
+                const checkInRef = doc(db, 'events', eventId, 'checkIns', scannedUserId);
+                await setDoc(checkInRef, {
+                    userId: scannedUserId,
+                    userName: userData.name || ticketData?.attendeeName,
+                    userBranch: userData.branch || ticketData?.branch,
+                    userYear: userData.year || ticketData?.year,
+                    checkedInAt: serverTimestamp(),
+                    checkedBy: user.uid,
+                    ticketId: ticketData?.ticketId || null,
+                });
 
-            // 3. Mark registration as attended (optional, if separate collection)
-            const registrationRef = doc(db, 'events', eventId, 'registrations', scannedUserId);
-            // Check if registration exists first or just set merge
-            await updateDoc(registrationRef, { status: 'attended' }).catch(err =>
-                console.log('No reg doc, skipping update'),
-            );
+                // 3. Mark registration as attended (optional, if separate collection)
+                const registrationRef = doc(db, 'events', eventId, 'registrations', scannedUserId);
+                // Check if registration exists first or just set merge
+                await updateDoc(registrationRef, { status: 'attended' }).catch(err =>
+                    console.log('No reg doc, skipping update'),
+                );
 
-            setScanResult({
-                status: 'success',
-                message: `Checked in ${userData.name || ticketData?.attendeeName}!`,
-                user: userData,
-            });
+                setScanResult({
+                    status: 'success',
+                    message: `Checked in ${userData.name || ticketData?.attendeeName}!`,
+                    user: userData,
+                });
+            } catch (err) {
+                if (err.code === 'unavailable' || err.message?.includes('offline') || err.message?.includes('network')) {
+                    await queueOfflineCheckIn(eventId, {
+                        userId: scannedUserId,
+                        userName: userData.name || ticketData?.attendeeName || 'Guest',
+                        userBranch: userData.branch || ticketData?.branch || 'N/A',
+                        userYear: userData.year || ticketData?.year || 'N/A',
+                        ticketId: ticketData?.ticketId || null
+                    });
+                    setScanResult({
+                        status: 'success',
+                        message: `Queued offline check-in for ${userData.name || ticketData?.attendeeName || 'Guest'}.`,
+                        user: userData,
+                    });
+                    return;
+                }
+                throw err;
+            }
         } catch (error) {
             console.error(error);
             setScanResult({ status: 'error', message: 'Check-in failed. Try again.' });

--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -33,38 +33,52 @@ export default function QRScannerScreen({ navigation, route }) {
         }
     }, []);
 
+    const handleOfflineCheckIn = async (eventId, scannedUserId, ticketData, userData) => {
+        const queued = await queueOfflineCheckIn(eventId, {
+            userId: scannedUserId,
+            userName: userData?.name || ticketData?.attendeeName || 'Guest',
+            userEmail: userData?.email || ticketData?.attendeeEmail || '',
+            userBranch: userData?.branch || ticketData?.branch || 'N/A',
+            userYear: userData?.year || ticketData?.year || 'N/A',
+            ticketId: ticketData?.ticketId || null,
+        });
+
+        if (!queued) {
+            setScanResult({ status: 'error', message: 'Offline — failed to save check-in locally.' });
+            return;
+        }
+
+        setScanResult({
+            status: 'success',
+            message: `Queued offline check-in for ${userData?.name || ticketData?.attendeeName || 'Guest'}.`,
+            user: userData || { name: ticketData?.attendeeName || 'Guest' },
+        });
+    };
+
     const handleBarCodeScanned = async ({ type, data }) => {
         if (scanned) return;
         setScanned(true);
 
         try {
-            // Parse QR code data - it's a JSON object from TicketScreen
             let scannedUserId;
             let ticketData;
 
             try {
-                // Try to parse as JSON first (from TicketScreen)
                 ticketData = JSON.parse(data);
                 scannedUserId = ticketData.userId;
 
-                // Validate that this ticket is for the current event
                 if (ticketData.eventId !== eventId) {
-                    setScanResult({
-                        status: 'error',
-                        message: 'This ticket is for a different event!',
-                    });
+                    setScanResult({ status: 'error', message: 'This ticket is for a different event!' });
                     return;
                 }
-            } catch (_e) {
-                // If JSON parsing fails, the QR is not a structured ticket — do NOT queue offline.
-                // We cannot revalidate a raw userId string at sync time.
+            } catch (err) {
+                console.error('Invalid QR code JSON format:', err);
                 setScanResult({ status: 'error', message: 'Invalid QR code format.' });
                 return;
             }
 
             console.log(`Scanned user: ${scannedUserId} for event: ${eventId}`);
 
-            // 1. Verify User
             let userSnap;
             try {
                 const userRef = doc(db, 'users', scannedUserId);
@@ -76,25 +90,7 @@ export default function QRScannerScreen({ navigation, route }) {
                 }
             } catch (err) {
                 if (err.code === 'unavailable' || err.message?.includes('offline') || err.message?.includes('network')) {
-                    const queued = await queueOfflineCheckIn(eventId, {
-                        userId: scannedUserId,
-                        userName: ticketData?.attendeeName || 'Guest',
-                        userEmail: ticketData?.attendeeEmail || '',
-                        userBranch: ticketData?.branch || 'N/A',
-                        userYear: ticketData?.year || 'N/A',
-                        ticketId: ticketData?.ticketId || null,
-                    });
-
-                    if (!queued) {
-                        setScanResult({ status: 'error', message: 'Offline — failed to save check-in locally.' });
-                        return;
-                    }
-
-                    setScanResult({
-                        status: 'success',
-                        message: `Queued offline check-in for ${ticketData?.attendeeName || 'Guest'}.`,
-                        user: { name: ticketData?.attendeeName || 'Guest' },
-                    });
+                    await handleOfflineCheckIn(eventId, scannedUserId, ticketData, null);
                     return;
                 }
                 throw err;
@@ -102,8 +98,6 @@ export default function QRScannerScreen({ navigation, route }) {
 
             const userData = userSnap.data();
 
-            // 2. CheckIn Logic — use the canonical checkInAttendee to ensure all
-            // invariants (ticket status, event stats, organizer metadata) are maintained.
             try {
                 const ticketPayload = {
                     id: ticketData?.ticketId || scannedUserId,
@@ -118,7 +112,6 @@ export default function QRScannerScreen({ navigation, route }) {
                 const result = await checkInAttendee(ticketPayload, eventId, user.uid, userData.name || 'Organizer');
 
                 if (!result.success) {
-                    // Already checked-in or ineligible — report, don't crash
                     setScanResult({ status: 'error', message: result.message || 'Check-in failed.' });
                     return;
                 }
@@ -130,25 +123,7 @@ export default function QRScannerScreen({ navigation, route }) {
                 });
             } catch (err) {
                 if (err.code === 'unavailable' || err.message?.includes('offline') || err.message?.includes('network')) {
-                    const queued = await queueOfflineCheckIn(eventId, {
-                        userId: scannedUserId,
-                        userName: userData.name || ticketData?.attendeeName || 'Guest',
-                        userEmail: userData.email || ticketData?.attendeeEmail || '',
-                        userBranch: userData.branch || ticketData?.branch || 'N/A',
-                        userYear: userData.year || ticketData?.year || 'N/A',
-                        ticketId: ticketData?.ticketId || null,
-                    });
-
-                    if (!queued) {
-                        setScanResult({ status: 'error', message: 'Offline — failed to save check-in locally.' });
-                        return;
-                    }
-
-                    setScanResult({
-                        status: 'success',
-                        message: `Queued offline check-in for ${userData.name || ticketData?.attendeeName || 'Guest'}.`,
-                        user: userData,
-                    });
+                    await handleOfflineCheckIn(eventId, scannedUserId, ticketData, userData);
                     return;
                 }
                 throw err;

--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -1,13 +1,11 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Camera } from 'expo-camera';
-import { addDoc, collection, doc, getDoc, serverTimestamp, updateDoc, setDoc } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import ScreenWrapper from '../components/ScreenWrapper';
 import WebQRScanner from '../components/WebQRScanner';
 import { useAuth } from '../lib/AuthContext';
-import { db } from '../lib/firebaseConfig';
-import { queueOfflineCheckIn } from '../lib/checkInService';
+import { queueOfflineCheckIn, checkInAttendee, validateTicket } from '../lib/checkInService';
 import { useTheme } from '../lib/ThemeContext';
 import PropTypes from 'prop-types';
 
@@ -56,9 +54,10 @@ export default function QRScannerScreen({ navigation, route }) {
                     return;
                 }
             } catch (_e) {
-                // If JSON parsing fails, treat as plain userId string (fallback)
-                console.log('JSON parsing failed, falling back to plain string format:', _e);
-                scannedUserId = data;
+                // If JSON parsing fails, the QR is not a structured ticket — do NOT queue offline.
+                // We cannot revalidate a raw userId string at sync time.
+                setScanResult({ status: 'error', message: 'Invalid QR code format.' });
+                return;
             }
 
             console.log(`Scanned user: ${scannedUserId} for event: ${eventId}`);
@@ -75,14 +74,19 @@ export default function QRScannerScreen({ navigation, route }) {
                 }
             } catch (err) {
                 if (err.code === 'unavailable' || err.message?.includes('offline') || err.message?.includes('network')) {
-                    await queueOfflineCheckIn(eventId, {
+                    const queued = await queueOfflineCheckIn(eventId, {
                         userId: scannedUserId,
                         userName: ticketData?.attendeeName || 'Guest',
                         userBranch: ticketData?.branch || 'N/A',
                         userYear: ticketData?.year || 'N/A',
-                        ticketId: ticketData?.ticketId || null
+                        ticketId: ticketData?.ticketId || null,
                     });
-                    
+
+                    if (!queued) {
+                        setScanResult({ status: 'error', message: 'Offline — failed to save check-in locally.' });
+                        return;
+                    }
+
                     setScanResult({
                         status: 'success',
                         message: `Queued offline check-in for ${ticketData?.attendeeName || 'Guest'}.`,
@@ -95,40 +99,47 @@ export default function QRScannerScreen({ navigation, route }) {
 
             const userData = userSnap.data();
 
-            // 2. CheckIn Logic
+            // 2. CheckIn Logic — use the canonical checkInAttendee to ensure all
+            // invariants (ticket status, event stats, organizer metadata) are maintained.
             try {
-                const checkInRef = doc(db, 'events', eventId, 'checkIns', scannedUserId);
-                await setDoc(checkInRef, {
+                const ticketPayload = {
+                    id: ticketData?.ticketId || scannedUserId,
                     userId: scannedUserId,
                     userName: userData.name || ticketData?.attendeeName,
-                    userBranch: userData.branch || ticketData?.branch,
-                    userYear: userData.year || ticketData?.year,
-                    checkedInAt: serverTimestamp(),
-                    checkedBy: user.uid,
-                    ticketId: ticketData?.ticketId || null,
-                });
+                    userEmail: userData.email || ticketData?.attendeeEmail || '',
+                    userYear: userData.year || ticketData?.year || 'N/A',
+                    userBranch: userData.branch || ticketData?.branch || 'N/A',
+                    receiverId: scannedUserId,
+                };
 
-                // 3. Mark registration as attended (optional, if separate collection)
-                const registrationRef = doc(db, 'events', eventId, 'registrations', scannedUserId);
-                // Check if registration exists first or just set merge
-                await updateDoc(registrationRef, { status: 'attended' }).catch(err =>
-                    console.log('No reg doc, skipping update'),
-                );
+                const result = await checkInAttendee(ticketPayload, eventId, user.uid, userData.name || 'Organizer');
+
+                if (!result.success) {
+                    // Already checked-in or ineligible — report, don't crash
+                    setScanResult({ status: 'error', message: result.message || 'Check-in failed.' });
+                    return;
+                }
 
                 setScanResult({
                     status: 'success',
-                    message: `Checked in ${userData.name || ticketData?.attendeeName}!`,
+                    message: result.message || `Checked in ${userData.name || ticketData?.attendeeName}!`,
                     user: userData,
                 });
             } catch (err) {
                 if (err.code === 'unavailable' || err.message?.includes('offline') || err.message?.includes('network')) {
-                    await queueOfflineCheckIn(eventId, {
+                    const queued = await queueOfflineCheckIn(eventId, {
                         userId: scannedUserId,
                         userName: userData.name || ticketData?.attendeeName || 'Guest',
                         userBranch: userData.branch || ticketData?.branch || 'N/A',
                         userYear: userData.year || ticketData?.year || 'N/A',
-                        ticketId: ticketData?.ticketId || null
+                        ticketId: ticketData?.ticketId || null,
                     });
+
+                    if (!queued) {
+                        setScanResult({ status: 'error', message: 'Offline — failed to save check-in locally.' });
+                        return;
+                    }
+
                     setScanResult({
                         status: 'success',
                         message: `Queued offline check-in for ${userData.name || ticketData?.attendeeName || 'Guest'}.`,

--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -1,10 +1,12 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Camera } from 'expo-camera';
+import { doc, getDoc } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { Dimensions, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import ScreenWrapper from '../components/ScreenWrapper';
 import WebQRScanner from '../components/WebQRScanner';
 import { useAuth } from '../lib/AuthContext';
+import { db } from '../lib/firebaseConfig';
 import { queueOfflineCheckIn, checkInAttendee } from '../lib/checkInService';
 import { useTheme } from '../lib/ThemeContext';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
# Description

Implemented offline QR check-in queue that uses AsyncStorage to store failed check-ins due to unstable network conditions, and created a sync mechanism to write idempotent check-ins into Firestore. Also added a UI banner inside the Attendance Dashboard for organizers to manually trigger synchronization.

Fixes #221

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Disabled network during a QR scan and verified it displays the "Queued (Offline)" UI state and pushes the ticket data to AsyncStorage.
- [x] Confirmed the Attendance Dashboard successfully reports the pending count by fetching from AsyncStorage.
- [x] Manually triggered synchronization after re-enabling network, and verified records were idempotently placed in Firestore via `setDoc`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline check-in queueing per event with deduplication and queued timestamps.
  * Manual sync that processes queued items, reports success/partial/failure, and updates counts.
  * “Offline Sync Pending” banner with a “Sync Now” button and spinner while syncing.
  * QR scanning now queues check-ins when network/offline errors occur; pending count refreshes when the screen gains focus.

* **Behavior Change**
  * QR payload parsing is stricter—invalid payloads now produce an error instead of falling back.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->