### PR TITLE
Refactor: Centralize Firestore collection paths

### DIFF
--- a/app/src/lib/AutomationService.js
+++ b/app/src/lib/AutomationService.js
@@ -2,6 +2,7 @@ import { collection, getDocs, query, where, updateDoc, doc } from 'firebase/fire
 import { db } from './firebaseConfig';
 import { sendBulkFeedbackRequest } from './EmailService';
 import participantService from './participantService';
+import { COLLECTIONS } from './firestorePaths';
 
 /**
  * Checks for all events owned by the user that have ended and need feedback requests sent.
@@ -13,7 +14,7 @@ export const checkAndTriggerAutomations = async userId => {
 
     try {
         const now = new Date();
-        const eventsRef = collection(db, 'events');
+        const eventsRef = collection(db, COLLECTIONS.EVENTS);
 
         // Query: Owner is user, feedback NOT sent
         const q = query(
@@ -63,7 +64,7 @@ export const checkAndTriggerAutomations = async userId => {
                 }
 
                 // 3. Update Flag (Even if 0 participants, mark done to stop checking)
-                await updateDoc(doc(db, 'events', eventDoc.id), {
+                await updateDoc(doc(db, COLLECTIONS.EVENTS, eventDoc.id), {
                     feedbackRequestSent: true,
                     feedbackRequestSentAt: new Date().toISOString(),
                 });

--- a/app/src/lib/firestorePaths.js
+++ b/app/src/lib/firestorePaths.js
@@ -1,0 +1,10 @@
+export const COLLECTIONS = {
+    EVENTS: 'events',
+    USERS: 'users',
+    FEEDBACK_REQUESTS: 'feedbackRequests',
+    REGISTRATIONS: 'registrations',
+};
+
+export const getUserParticipatingPath = userId => `${COLLECTIONS.USERS}/${userId}/participating`;
+export const getEventCheckInsPath = eventId => `${COLLECTIONS.EVENTS}/${eventId}/checkIns`;
+export const getEventFeedbackPath = eventId => `${COLLECTIONS.EVENTS}/${eventId}/feedback`;

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -399,7 +399,10 @@ export default function AttendanceDashboard({ route, navigation }) {
     const handleExportFormResponses = async () => {
         setExporting(true);
         try {
-            const q = query(collection(db, COLLECTIONS.REGISTRATIONS), where('eventId', '==', eventId));
+            const q = query(
+                collection(db, COLLECTIONS.REGISTRATIONS),
+                where('eventId', '==', eventId),
+            );
             const snapshot = await getDocs(q);
 
             if (snapshot.empty) {

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -36,6 +36,7 @@ import participantService from '../lib/participantService';
 import { useTheme } from '../lib/ThemeContext';
 import { sendBulkAnnouncement, sendBulkFeedbackRequest } from '../lib/EmailService';
 import PropTypes from 'prop-types';
+import { COLLECTIONS, getEventCheckInsPath, getEventFeedbackPath } from '../lib/firestorePaths';
 
 export default function AttendanceDashboard({ route, navigation }) {
     const { width: screenWidth } = useWindowDimensions();
@@ -87,7 +88,7 @@ export default function AttendanceDashboard({ route, navigation }) {
             const count = await sendBulkFeedbackRequest(participants, eventTitle, eventId);
 
             // Update event to mark feedback as sent
-            await updateDoc(doc(db, 'events', eventId), {
+            await updateDoc(doc(db, COLLECTIONS.EVENTS, eventId), {
                 feedbackRequestSent: true,
                 feedbackRequestSentAt: new Date().toISOString(),
             });
@@ -149,7 +150,7 @@ export default function AttendanceDashboard({ route, navigation }) {
 
     // Fetch Event Data to check for Custom Form
     useEffect(() => {
-        getDoc(doc(db, 'events', eventId)).then(snap => {
+        getDoc(doc(db, COLLECTIONS.EVENTS, eventId)).then(snap => {
             if (snap.exists()) setEventData(snap.data());
         });
     }, [eventId]);
@@ -210,7 +211,7 @@ export default function AttendanceDashboard({ route, navigation }) {
     // Real-time check-ins listener
     useEffect(() => {
         const q = query(
-            collection(db, 'events', eventId, 'checkIns'),
+            collection(db, getEventCheckInsPath(eventId)),
             orderBy('checkedInAt', 'desc'),
         );
 
@@ -365,7 +366,7 @@ export default function AttendanceDashboard({ route, navigation }) {
     const handleExportReviews = async () => {
         setExporting(true);
         try {
-            const feedbackRef = collection(db, `events/${eventId}/feedback`);
+            const feedbackRef = collection(db, getEventFeedbackPath(eventId));
             const snapshot = await getDocs(feedbackRef);
 
             if (snapshot.empty) {
@@ -398,7 +399,7 @@ export default function AttendanceDashboard({ route, navigation }) {
     const handleExportFormResponses = async () => {
         setExporting(true);
         try {
-            const q = query(collection(db, 'registrations'), where('eventId', '==', eventId));
+            const q = query(collection(db, COLLECTIONS.REGISTRATIONS), where('eventId', '==', eventId));
             const snapshot = await getDocs(q);
 
             if (snapshot.empty) {

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -199,7 +199,11 @@ export default function UserFeed() {
                 if (loadMore && lastVisible) {
                     qConstraints.push(startAfter(lastVisible));
                 }
-                const q = query(collection(db, COLLECTIONS.EVENTS), ...qConstraints, limit(PAGE_SIZE));
+                const q = query(
+                    collection(db, COLLECTIONS.EVENTS),
+                    ...qConstraints,
+                    limit(PAGE_SIZE),
+                );
 
                 const snapshot = await getDocs(q);
                 const list = [];

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -32,6 +32,7 @@ import { submitFeedback } from '../lib/feedbackService';
 import { db } from '../lib/firebaseConfig';
 import { useTheme } from '../lib/ThemeContext';
 import { useNavigation } from '@react-navigation/native';
+import { COLLECTIONS, getUserParticipatingPath } from '../lib/firestorePaths';
 
 let MapView = null;
 let Marker = null;
@@ -74,7 +75,7 @@ export default function UserFeed() {
     // Listen for my registrations
     useEffect(() => {
         if (!user) return;
-        const q = collection(db, 'users', user.uid, 'participating');
+        const q = collection(db, getUserParticipatingPath(user.uid));
         const unsub = onSnapshot(q, snap => {
             setParticipatingIds(snap.docs.map(d => d.id));
         });
@@ -94,7 +95,7 @@ export default function UserFeed() {
         if (!user) return;
 
         const feedbackQuery = query(
-            collection(db, 'feedbackRequests'),
+            collection(db, COLLECTIONS.FEEDBACK_REQUESTS),
             where('userId', '==', user.uid),
             where('status', '==', 'pending'),
             limit(1), // Show one at a time
@@ -125,7 +126,7 @@ export default function UserFeed() {
             try {
                 const now = new Date().toISOString();
                 const q = query(
-                    collection(db, 'events'),
+                    collection(db, COLLECTIONS.EVENTS),
                     where('status', '==', 'active'),
                     where('startAt', '>=', now),
                     orderBy('startAt', 'asc'),
@@ -198,7 +199,7 @@ export default function UserFeed() {
                 if (loadMore && lastVisible) {
                     qConstraints.push(startAfter(lastVisible));
                 }
-                const q = query(collection(db, 'events'), ...qConstraints, limit(PAGE_SIZE));
+                const q = query(collection(db, COLLECTIONS.EVENTS), ...qConstraints, limit(PAGE_SIZE));
 
                 const snapshot = await getDocs(q);
                 const list = [];


### PR DESCRIPTION
Fixes #231

**Changes:**
- Created `src/lib/firestorePaths.js` to store base `COLLECTIONS` constants and path helper functions.
- Migrated `AutomationService`, `UserFeed`, and `AttendanceDashboard` to use the centralized constants and helpers instead of raw hardcoded collection strings.
- Removed duplicated strings like `'events'`, `'feedbackRequests'`, and nested paths like `events/${eventId}/checkIns`.

**Testing:**
- Verified no remaining hardcoded strings for migrated collections in affected files.
- Ensures compatibility with existing queries and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Firestore collection names and path helpers for consistent data access across the app, with UI features (attendance dashboard, user feed, feedback flow, exports) switched to use these shared paths to reduce inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->