### PR TITLE
test: add RTL screen coverage for screens

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -68,7 +68,7 @@
                 "eslint-plugin-prettier": "^5.0.0",
                 "eslint-plugin-react-hooks": "^5.0.0",
                 "globals": "^17.6.0",
-                "jest": "^29.2.1",
+                "jest": "^29.7.0",
                 "jest-expo": "~52.0.6",
                 "prettier": "^3.8.3",
                 "react-test-renderer": "18.3.1",

--- a/app/package.json
+++ b/app/package.json
@@ -95,7 +95,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "globals": "^17.6.0",
-        "jest": "^29.2.1",
+        "jest": "^29.7.0",
         "jest-expo": "~52.0.6",
         "prettier": "^3.8.3",
         "react-test-renderer": "18.3.1",

--- a/app/src/screens/__tests__/AuthScreen.test.js
+++ b/app/src/screens/__tests__/AuthScreen.test.js
@@ -1,3 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import AuthScreen from '../AuthScreen';
+
 jest.mock('@expo/vector-icons', () => {
     const React = require('react');
     return {
@@ -67,10 +71,6 @@ jest.mock('../../lib/ThemeContext', () => ({
         },
     }),
 }));
-
-import React from 'react';
-import { render } from '@testing-library/react-native';
-import AuthScreen from '../AuthScreen';
 
 describe('AuthScreen', () => {
     it('renders login screen', () => {

--- a/app/src/screens/__tests__/AuthScreen.test.js
+++ b/app/src/screens/__tests__/AuthScreen.test.js
@@ -1,0 +1,80 @@
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    return {
+        Ionicons: () => React.createElement('Icon'),
+    };
+});
+
+jest.mock('expo-font', () => ({
+    isLoaded: jest.fn(() => true),
+    loadAsync: jest.fn(),
+}));
+
+jest.mock('expo-auth-session', () => ({
+    makeRedirectUri: jest.fn(() => 'mock-redirect-uri'),
+}));
+
+jest.mock('expo-auth-session/providers/google', () => ({
+    useAuthRequest: jest.fn(() => [null, null, jest.fn()]),
+}));
+
+jest.mock('expo-web-browser', () => ({
+    maybeCompleteAuthSession: jest.fn(),
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+    LinearGradient: ({ children }) => children,
+}));
+
+jest.mock('firebase/auth', () => ({
+    GoogleAuthProvider: {
+        credential: jest.fn(),
+    },
+    signInWithCredential: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+    doc: jest.fn(),
+    getDoc: jest.fn(),
+    setDoc: jest.fn(),
+}));
+
+jest.mock('../../lib/firebaseConfig', () => ({
+    auth: {},
+    db: {},
+}));
+
+jest.mock('../../lib/AuthContext', () => ({
+    useAuth: () => ({
+        signIn: jest.fn(),
+        signUp: jest.fn(),
+        saveGoogleAccountCredentials: jest.fn(),
+    }),
+}));
+
+jest.mock('../../lib/ThemeContext', () => ({
+    useTheme: () => ({
+        theme: {
+            colors: {
+                background: '#fff',
+                surface: '#fff',
+                text: '#000',
+                textSecondary: '#666',
+                primary: '#000',
+                border: '#ddd',
+                error: '#f00',
+            },
+        },
+    }),
+}));
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import AuthScreen from '../AuthScreen';
+
+describe('AuthScreen', () => {
+    it('renders login screen', () => {
+        const { getAllByText } = render(<AuthScreen />);
+        expect(getAllByText(/sign in/i).length).toBeGreaterThan(0);
+    });
+});

--- a/app/src/screens/__tests__/EventRegistrationFormScreen.test.js
+++ b/app/src/screens/__tests__/EventRegistrationFormScreen.test.js
@@ -1,5 +1,8 @@
+/* eslint-disable import/first */
+
 jest.mock('@expo/vector-icons', () => {
     const React = require('react');
+
     return {
         Ionicons: () => React.createElement('Icon'),
         MaterialIcons: () => React.createElement('Icon'),
@@ -14,9 +17,20 @@ jest.mock('expo-font', () => ({
 
 jest.mock('../../components/ScreenWrapper', () => {
     const React = require('react');
+    const PropTypes = require('prop-types');
     const { View } = require('react-native');
 
-    return ({ children }) => <View>{children}</View>;
+    function MockScreenWrapper({ children }) {
+        return <View>{children}</View>;
+    }
+
+    MockScreenWrapper.propTypes = {
+        children: PropTypes.node,
+    };
+
+    MockScreenWrapper.displayName = 'MockScreenWrapper';
+
+    return MockScreenWrapper;
 });
 
 jest.mock('react-native-confetti-cannon', () => 'ConfettiCannon');
@@ -35,7 +49,7 @@ jest.mock('firebase/firestore', () => ({
         Promise.resolve({
             exists: () => true,
             data: () => ({}),
-        })
+        }),
     ),
     arrayUnion: jest.fn(),
     runTransaction: jest.fn(),
@@ -90,7 +104,7 @@ describe('EventRegistrationFormScreen', () => {
         };
 
         const { getByText } = render(
-            <EventRegistrationFormScreen navigation={navigation} route={route} />
+            <EventRegistrationFormScreen navigation={navigation} route={route} />,
         );
 
         expect(getByText('Registration')).toBeTruthy();

--- a/app/src/screens/__tests__/EventRegistrationFormScreen.test.js
+++ b/app/src/screens/__tests__/EventRegistrationFormScreen.test.js
@@ -1,0 +1,99 @@
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    return {
+        Ionicons: () => React.createElement('Icon'),
+        MaterialIcons: () => React.createElement('Icon'),
+        FontAwesome: () => React.createElement('Icon'),
+    };
+});
+
+jest.mock('expo-font', () => ({
+    isLoaded: jest.fn(() => true),
+    loadAsync: jest.fn(),
+}));
+
+jest.mock('../../components/ScreenWrapper', () => {
+    const React = require('react');
+    const { View } = require('react-native');
+
+    return ({ children }) => <View>{children}</View>;
+});
+
+jest.mock('react-native-confetti-cannon', () => 'ConfettiCannon');
+
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+jest.mock('../../lib/notificationService', () => ({
+    scheduleEventReminder: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+    collection: jest.fn(),
+    doc: jest.fn(),
+    increment: jest.fn(),
+    getDoc: jest.fn(() =>
+        Promise.resolve({
+            exists: () => true,
+            data: () => ({}),
+        })
+    ),
+    arrayUnion: jest.fn(),
+    runTransaction: jest.fn(),
+}));
+
+jest.mock('../../lib/firebaseConfig', () => ({
+    db: {},
+}));
+
+jest.mock('../../lib/AuthContext', () => ({
+    useAuth: () => ({
+        user: {
+            uid: '123',
+        },
+    }),
+}));
+
+jest.mock('../../lib/ThemeContext', () => ({
+    useTheme: () => ({
+        theme: {
+            colors: {
+                text: '#000',
+                primary: '#000',
+                textSecondary: '#666',
+                surface: '#fff',
+                border: '#ddd',
+            },
+        },
+    }),
+}));
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import EventRegistrationFormScreen from '../EventRegistrationFormScreen';
+
+describe('EventRegistrationFormScreen', () => {
+    it('renders registration screen', () => {
+        const route = {
+            params: {
+                event: {
+                    id: 'event-1',
+                    title: 'Test Event',
+                    customFormSchema: [],
+                },
+            },
+        };
+
+        const navigation = {
+            navigate: jest.fn(),
+            goBack: jest.fn(),
+            popToTop: jest.fn(),
+        };
+
+        const { getByText } = render(
+            <EventRegistrationFormScreen navigation={navigation} route={route} />
+        );
+
+        expect(getByText('Registration')).toBeTruthy();
+        expect(getByText('Test Event')).toBeTruthy();
+    });
+});

--- a/app/src/screens/__tests__/QRScannerScreen.test.js
+++ b/app/src/screens/__tests__/QRScannerScreen.test.js
@@ -3,9 +3,6 @@ jest.mock('../../lib/checkInService', () => ({
   checkInAttendee: jest.fn(),
 }));
 
-import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
-
 jest.mock('expo-camera', () => ({
     Camera: {
         requestCameraPermissionsAsync: jest.fn(() =>
@@ -46,6 +43,8 @@ jest.mock('../../lib/ThemeContext', () => ({
     }),
 }));
 
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
 import QRScannerScreen from '../QRScannerScreen';
 
 describe('QRScannerScreen', () => {

--- a/app/src/screens/__tests__/QRScannerScreen.test.js
+++ b/app/src/screens/__tests__/QRScannerScreen.test.js
@@ -1,6 +1,6 @@
 jest.mock('../../lib/checkInService', () => ({
-  queueOfflineCheckIn: jest.fn(),
-  checkInAttendee: jest.fn(),
+    queueOfflineCheckIn: jest.fn(),
+    checkInAttendee: jest.fn(),
 }));
 
 jest.mock('expo-camera', () => ({
@@ -44,8 +44,13 @@ jest.mock('../../lib/ThemeContext', () => ({
 }));
 
 import React from 'react';
+import { Platform } from 'react-native';
 import { render, waitFor } from '@testing-library/react-native';
 import QRScannerScreen from '../QRScannerScreen';
+
+beforeAll(() => {
+    jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
+});
 
 describe('QRScannerScreen', () => {
     it('shows no camera access message when permission denied', async () => {

--- a/app/src/screens/__tests__/QRScannerScreen.test.js
+++ b/app/src/screens/__tests__/QRScannerScreen.test.js
@@ -1,3 +1,8 @@
+import React from 'react';
+import { Platform } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import QRScannerScreen from '../QRScannerScreen';
+
 jest.mock('../../lib/checkInService', () => ({
     queueOfflineCheckIn: jest.fn(),
     checkInAttendee: jest.fn(),
@@ -8,7 +13,7 @@ jest.mock('expo-camera', () => ({
         requestCameraPermissionsAsync: jest.fn(() =>
             Promise.resolve({
                 status: 'denied',
-            })
+            }),
         ),
     },
 }));
@@ -43,14 +48,7 @@ jest.mock('../../lib/ThemeContext', () => ({
     }),
 }));
 
-import React from 'react';
-import { Platform } from 'react-native';
-import { render, waitFor } from '@testing-library/react-native';
-import QRScannerScreen from '../QRScannerScreen';
-
-beforeAll(() => {
-    jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
-});
+Platform.OS = 'android';
 
 describe('QRScannerScreen', () => {
     it('shows no camera access message when permission denied', async () => {
@@ -65,9 +63,7 @@ describe('QRScannerScreen', () => {
             goBack: jest.fn(),
         };
 
-        const { getByText } = render(
-            <QRScannerScreen navigation={navigation} route={route} />
-        );
+        const { getByText } = render(<QRScannerScreen navigation={navigation} route={route} />);
 
         await waitFor(() => {
             expect(getByText(/no access to camera/i)).toBeTruthy();

--- a/app/src/screens/__tests__/QRScannerScreen.test.js
+++ b/app/src/screens/__tests__/QRScannerScreen.test.js
@@ -48,7 +48,15 @@ jest.mock('../../lib/ThemeContext', () => ({
     }),
 }));
 
-Platform.OS = 'android';
+const originalPlatform = Platform.OS;
+
+beforeAll(() => {
+    Platform.OS = 'android';
+});
+
+afterAll(() => {
+    Platform.OS = originalPlatform;
+});
 
 describe('QRScannerScreen', () => {
     it('shows no camera access message when permission denied', async () => {

--- a/app/src/screens/__tests__/QRScannerScreen.test.js
+++ b/app/src/screens/__tests__/QRScannerScreen.test.js
@@ -1,0 +1,72 @@
+jest.mock('../../lib/checkInService', () => ({
+  queueOfflineCheckIn: jest.fn(),
+  checkInAttendee: jest.fn(),
+}));
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+jest.mock('expo-camera', () => ({
+    Camera: {
+        requestCameraPermissionsAsync: jest.fn(() =>
+            Promise.resolve({
+                status: 'denied',
+            })
+        ),
+    },
+}));
+
+jest.mock('firebase/firestore', () => ({
+    doc: jest.fn(),
+    getDoc: jest.fn(),
+}));
+
+jest.mock('../../lib/firebaseConfig', () => ({
+    db: {},
+}));
+
+jest.mock('../../lib/AuthContext', () => ({
+    useAuth: () => ({
+        user: {
+            uid: '123',
+        },
+    }),
+}));
+
+jest.mock('../../lib/ThemeContext', () => ({
+    useTheme: () => ({
+        theme: {
+            colors: {
+                surface: '#fff',
+                text: '#000',
+                textSecondary: '#666',
+                primary: '#000',
+            },
+        },
+    }),
+}));
+
+import QRScannerScreen from '../QRScannerScreen';
+
+describe('QRScannerScreen', () => {
+    it('shows no camera access message when permission denied', async () => {
+        const route = {
+            params: {
+                eventId: '1',
+                eventTitle: 'Test Event',
+            },
+        };
+
+        const navigation = {
+            goBack: jest.fn(),
+        };
+
+        const { getByText } = render(
+            <QRScannerScreen navigation={navigation} route={route} />
+        );
+
+        await waitFor(() => {
+            expect(getByText(/no access to camera/i)).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
# Description

Added React Testing Library screen tests for critical untested screens.

This PR adds coverage for:
- AuthScreen
- EventRegistrationFormScreen
- QRScannerScreen camera permission denied case

Firebase and native/expo dependencies are mocked to keep tests stable in CI.

Fixes #234 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with:

- [x] `npm test`

Result:
- 13 test suites passed
- 61 tests passed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added UI tests for authentication, event registration, and QR scanning screens, covering permission and rendering scenarios with external integrations mocked for stability.

* **Chores**
  * Upgraded testing tooling to a newer stable version to keep test runner current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->