### PR TITLE
Batch dailyDigest users in pages and respect digestOptIn field

### DIFF
--- a/cloud-functions/src/dailyDigest.ts
+++ b/cloud-functions/src/dailyDigest.ts
@@ -3,6 +3,8 @@ import * as functions from "firebase-functions";
 import Expo from 'expo-server-sdk';
 const expo = new Expo();
 
+const PAGE_SIZE = 500;
+
 export const sendDailyDigest = functions.https.onCall(async (data, context) => {
     if (!context.auth) {
         throw new functions.https.HttpsError('unauthenticated', 'The function must be called while authenticated.');
@@ -17,7 +19,6 @@ export const sendDailyDigest = functions.https.onCall(async (data, context) => {
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
 
-    // efficient query for "today's events"
     const eventsRef = db.collection('events');
     const snapshot = await eventsRef
         .where('startAt', '>=', today.toISOString())
@@ -30,40 +31,69 @@ export const sendDailyDigest = functions.https.onCall(async (data, context) => {
         return { success: true, message: "No events today." };
     }
 
-    // Broadcast
-    const usersSnapshot = await db.collection('users').get();
-    const messages: any[] = [];
-    const batch = db.batch();
+    let lastDoc: admin.firestore.DocumentSnapshot | null = null;
+    const allMessages: any[] = [];
+    let processedCount = 0;
 
-    usersSnapshot.forEach(userDoc => {
-        const userData = userDoc.data();
-        const pushToken = userData.pushToken;
+    while (true) {
+        let query: admin.firestore.Query = db
+            .collection('users')
+            .orderBy(admin.firestore.FieldPath.documentId())
+            .limit(PAGE_SIZE);
 
-        // In-App
-        const notifRef = userDoc.ref.collection('notifications').doc();
-        batch.set(notifRef, {
-            title: 'Daily Digest 📅',
-            body: `There are ${count} events happening today!`,
-            createdAt: admin.firestore.FieldValue.serverTimestamp(),
-            read: false
-        });
+        if (lastDoc) {
+            query = query.startAfter(lastDoc);
+        }
 
-        if (pushToken && Expo.isExpoPushToken(pushToken)) {
-            messages.push({
-                to: pushToken,
-                sound: 'default',
+        const usersSnapshot = await query.get();
+
+        if (usersSnapshot.empty) {
+            break;
+        }
+
+        const batch = db.batch();
+        const pageMessages: any[] = [];
+
+        usersSnapshot.forEach(userDoc => {
+            const userData = userDoc.data();
+
+            if (userData.digestOptIn === false) {
+                return;
+            }
+
+            const notifRef = userDoc.ref.collection('notifications').doc();
+            batch.set(notifRef, {
                 title: 'Daily Digest 📅',
                 body: `There are ${count} events happening today!`,
-                data: { url: '/home' }, // Deep link to home or events feed
+                createdAt: admin.firestore.FieldValue.serverTimestamp(),
+                read: false
             });
+
+            const pushToken = userData.pushToken;
+            if (pushToken && Expo.isExpoPushToken(pushToken)) {
+                pageMessages.push({
+                    to: pushToken,
+                    sound: 'default',
+                    title: 'Daily Digest 📅',
+                    body: `There are ${count} events happening today!`,
+                    data: { url: '/home' },
+                });
+            }
+        });
+
+        await batch.commit();
+        allMessages.push(...pageMessages);
+        processedCount += usersSnapshot.size;
+
+        lastDoc = usersSnapshot.docs[usersSnapshot.docs.length - 1];
+
+        if (usersSnapshot.size < PAGE_SIZE) {
+            break;
         }
-    });
+    }
 
-    await batch.commit();
-
-    // Send Pushes
-    if (messages.length > 0) {
-        let chunks = expo.chunkPushNotifications(messages);
+    if (allMessages.length > 0) {
+        let chunks = expo.chunkPushNotifications(allMessages);
         for (let chunk of chunks) {
             try {
                 await expo.sendPushNotificationsAsync(chunk);
@@ -73,5 +103,5 @@ export const sendDailyDigest = functions.https.onCall(async (data, context) => {
         }
     }
 
-    return { success: true, count };
+    return { success: true, count, processed: processedCount };
 });

--- a/cloud-functions/src/dailyDigest.ts
+++ b/cloud-functions/src/dailyDigest.ts
@@ -28,11 +28,10 @@ export const sendDailyDigest = functions.https.onCall(async (data, context) => {
     const count = snapshot.size;
 
     if (count === 0) {
-        return { success: true, message: "No events today." };
+        return { success: true, message: "No events today.", count: 0, processed: 0 };
     }
 
     let lastDoc: admin.firestore.DocumentSnapshot | null = null;
-    const allMessages: any[] = [];
     let processedCount = 0;
 
     while (true) {
@@ -82,24 +81,24 @@ export const sendDailyDigest = functions.https.onCall(async (data, context) => {
         });
 
         await batch.commit();
-        allMessages.push(...pageMessages);
+
+        if (pageMessages.length > 0) {
+            let chunks = expo.chunkPushNotifications(pageMessages);
+            for (let chunk of chunks) {
+                try {
+                    await expo.sendPushNotificationsAsync(chunk);
+                } catch (error) {
+                    console.error("Error sending digest chunks", error);
+                }
+            }
+        }
+
         processedCount += usersSnapshot.size;
 
         lastDoc = usersSnapshot.docs[usersSnapshot.docs.length - 1];
 
         if (usersSnapshot.size < PAGE_SIZE) {
             break;
-        }
-    }
-
-    if (allMessages.length > 0) {
-        let chunks = expo.chunkPushNotifications(allMessages);
-        for (let chunk of chunks) {
-            try {
-                await expo.sendPushNotificationsAsync(chunk);
-            } catch (error) {
-                console.error("Error sending digest chunks", error);
-            }
         }
     }
 


### PR DESCRIPTION
## What this fixes

The `sendDailyDigest` Cloud Function in `cloud-functions/src/dailyDigest.ts` loaded every user document in a single `collection('users').get()` call, which does not scale past a few thousand users. It also wrote all in-app notifications into a single `batch.commit()`, which hard-fails when there are more than 500 users (Firestore's batch operation limit). Additionally, there was no way for users to opt out of receiving daily digests.

## Root cause

The function used an unbounded `usersSnapshot` query with no pagination and accumulated all notification writes into one batch. The 500-op limit per batch means the function breaks for any user base above 500.

## What changed

- `cloud-functions/src/dailyDigest.ts`: Replaced the single `.get()` with a `while` loop using `orderBy(documentId).limit(500)` and `startAfter` cursor pagination
- `cloud-functions/src/dailyDigest.ts`: Each page commits its own batch, keeping writes within the 500-op limit
- `cloud-functions/src/dailyDigest.ts`: Added a `digestOptIn === false` guard so opted-out users are skipped
- `cloud-functions/src/dailyDigest.ts`: Return value now includes `processed` count for observability
- Admin auth check (added in #258) is preserved unchanged

## How to verify

1. Deploy the functions: `firebase deploy --only functions`
2. As an admin, call `sendDailyDigest` via a Firebase Callable Function invocation with a Firestore `users` collection that has more than 500 documents
3. Confirm the function completes with `{ success: true, count: N, processed: M }` where M is the total number of users processed across all pages
4. For a user with `digestOptIn: false` set, confirm no in-app notification or push notification is created
5. For a user without the `digestOptIn` field (or with `true`), confirm they receive the digest as before

## Edge cases considered

- **Exactly 500 users**: Single batch, works as before
- **0 users**: The query returns empty on the first iteration and breaks the loop immediately (no events short-circuits at line 30, but if there are events with 0 users, this handles it)
- **Users added between pages**: Cursor-based pagination ensures each user is processed exactly once, even if new users are created mid-execution
- **Users deleted between pages**: `startAfter` references a document snapshot, so a deleted cursor doc does not cause issues
- **digestOptIn not set**: `undefined === false` is `false`, so users without the field receive digests by default (backward compatible)
- **digestOptIn set to true explicitly**: `true === false` is `false`, they receive the digest (correct)
- **digestOptIn set to a non-boolean truthy value**: Not equal to `false`, they receive the digest (safe default)
- **digestOptIn explicitly false**: Skipped entirely (no in-app notification, no push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Daily digest notifications now process and deliver more efficiently and scalably for large user bases.
  * Improved handling of user opt-out preferences to ensure only opted-in users receive digests.
* **User-Facing Behavior**
  * Delivery reports are more informative and now explicitly indicate when there are no events to send.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->