### PR TITLE
Add unlockable profile badges by user level

### DIFF
--- a/app/src/lib/__tests__/profileBadges.test.js
+++ b/app/src/lib/__tests__/profileBadges.test.js
@@ -1,0 +1,64 @@
+import {
+    canUseProfileBadge,
+    DEFAULT_PROFILE_BADGE_ID,
+    getDefaultProfileBadge,
+    getProfileBadgeById,
+    getSafeSelectedProfileBadge,
+    getUnlockedProfileBadges,
+    PROFILE_BADGES,
+} from '../profileBadges';
+import { USER_LEVELS } from '../userLevels';
+
+const ionicons = require('@expo/vector-icons/build/vendor/react-native-vector-icons/glyphmaps/Ionicons.json');
+
+describe('profileBadges', () => {
+    test('returns badge metadata by id', () => {
+        expect(getProfileBadgeById('club-hopper').label).toBe('Club Hopper');
+        expect(getProfileBadgeById('missing-badge')).toBeNull();
+    });
+
+    test('returns the default badge', () => {
+        expect(getDefaultProfileBadge().id).toBe(DEFAULT_PROFILE_BADGE_ID);
+    });
+
+    test('returns all badges unlocked at a user level', () => {
+        const levelOneBadges = getUnlockedProfileBadges(1);
+        const levelThreeBadges = getUnlockedProfileBadges(3);
+
+        expect(levelOneBadges.every(badge => badge.requiredLevel <= 1)).toBe(true);
+        expect(levelThreeBadges.every(badge => badge.requiredLevel <= 3)).toBe(true);
+        expect(levelThreeBadges.length).toBeGreaterThan(levelOneBadges.length);
+    });
+
+    test('checks whether a badge can be used at the current level', () => {
+        expect(canUseProfileBadge('first-rsvp', 1)).toBe(true);
+        expect(canUseProfileBadge('legend-mode', 4)).toBe(false);
+        expect(canUseProfileBadge('missing-badge', 5)).toBe(false);
+    });
+
+    test('falls back to default badge when saved badge is missing or locked', () => {
+        expect(getSafeSelectedProfileBadge('legend-mode', 2).id).toBe(DEFAULT_PROFILE_BADGE_ID);
+        expect(getSafeSelectedProfileBadge('missing-badge', 5).id).toBe(DEFAULT_PROFILE_BADGE_ID);
+    });
+
+    test('keeps the selected badge when it is unlocked', () => {
+        expect(getSafeSelectedProfileBadge('campus-star', 5).id).toBe('campus-star');
+    });
+
+    test('keeps badge ids unique', () => {
+        const ids = PROFILE_BADGES.map(badge => badge.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    test('uses valid Ionicons names', () => {
+        expect(PROFILE_BADGES.every(badge => ionicons[badge.icon])).toBe(true);
+    });
+
+    test('does not duplicate level names or icons', () => {
+        const levelTitles = new Set(USER_LEVELS.map(level => level.title));
+        const levelIcons = new Set(USER_LEVELS.map(level => level.icon));
+
+        expect(PROFILE_BADGES.some(badge => levelTitles.has(badge.label))).toBe(false);
+        expect(PROFILE_BADGES.some(badge => levelIcons.has(badge.icon))).toBe(false);
+    });
+});

--- a/app/src/lib/profileBadges.js
+++ b/app/src/lib/profileBadges.js
@@ -1,0 +1,121 @@
+export const DEFAULT_PROFILE_BADGE_ID = 'fresh-face';
+
+export const PROFILE_BADGES = [
+    {
+        id: 'fresh-face',
+        label: 'Day One Drip',
+        description: 'New on campus, already showing up',
+        requiredLevel: 1,
+        icon: 'shirt-outline',
+        color: '#38BDF8',
+    },
+    {
+        id: 'first-rsvp',
+        label: 'Snack Pass',
+        description: 'Found the event with food first',
+        requiredLevel: 1,
+        icon: 'pizza-outline',
+        color: '#22C55E',
+    },
+    {
+        id: 'campus-rookie',
+        label: 'Map Wanderer',
+        description: 'Lost once, explored twice',
+        requiredLevel: 1,
+        icon: 'trail-sign-outline',
+        color: '#F97316',
+    },
+    {
+        id: 'club-hopper',
+        label: 'Club Hopper',
+        description: 'Checking every club table before lunch',
+        requiredLevel: 2,
+        icon: 'walk-outline',
+        color: '#8B5CF6',
+    },
+    {
+        id: 'map-runner',
+        label: 'Venue Scout',
+        description: 'Knows where the good rooms are',
+        requiredLevel: 2,
+        icon: 'earth-outline',
+        color: '#14B8A6',
+    },
+    {
+        id: 'event-regular',
+        label: 'Front Row Fan',
+        description: 'Somehow always near the stage',
+        requiredLevel: 3,
+        icon: 'megaphone-outline',
+        color: '#F59E0B',
+    },
+    {
+        id: 'ticket-collector',
+        label: 'Memory Collector',
+        description: 'Turns events into stories',
+        requiredLevel: 3,
+        icon: 'camera-outline',
+        color: '#EC4899',
+    },
+    {
+        id: 'crowd-favorite',
+        label: 'Hype Signal',
+        description: 'Brings the energy with them',
+        requiredLevel: 4,
+        icon: 'radio-outline',
+        color: '#EF4444',
+    },
+    {
+        id: 'campus-connector',
+        label: 'Squad Builder',
+        description: 'Never attends alone for long',
+        requiredLevel: 4,
+        icon: 'chatbubbles-outline',
+        color: '#6366F1',
+    },
+    {
+        id: 'campus-star',
+        label: 'Aftermovie Lead',
+        description: 'The highlight reel needs them',
+        requiredLevel: 5,
+        icon: 'film-outline',
+        color: '#A855F7',
+    },
+    {
+        id: 'legend-mode',
+        label: 'Campus Myth',
+        description: 'People mention them before events start',
+        requiredLevel: 5,
+        icon: 'rocket-outline',
+        color: '#EAB308',
+    },
+];
+
+export const getProfileBadgeById = badgeId => {
+    return PROFILE_BADGES.find(badge => badge.id === badgeId) || null;
+};
+
+export const getDefaultProfileBadge = () => {
+    return getProfileBadgeById(DEFAULT_PROFILE_BADGE_ID);
+};
+
+export const getUnlockedProfileBadges = level => {
+    const safeLevel = Number.isFinite(Number(level)) ? Number(level) : 1;
+    return PROFILE_BADGES.filter(badge => badge.requiredLevel <= safeLevel);
+};
+
+export const canUseProfileBadge = (badgeId, level) => {
+    const badge = getProfileBadgeById(badgeId);
+    if (!badge) return false;
+
+    const safeLevel = Number.isFinite(Number(level)) ? Number(level) : 1;
+    return badge.requiredLevel <= safeLevel;
+};
+
+export const getSafeSelectedProfileBadge = (badgeId, level) => {
+    if (canUseProfileBadge(badgeId, level)) {
+        return getProfileBadgeById(badgeId);
+    }
+
+    return getDefaultProfileBadge();
+};

--- a/app/src/screens/AuthScreen.js
+++ b/app/src/screens/AuthScreen.js
@@ -460,7 +460,6 @@ const styles = StyleSheet.create({
         flex: 1,
         fontSize: 16,
         paddingVertical: 0,
-        outlineStyle: 'none',
         backgroundColor: 'transparent',
     },
     authButton: {

--- a/app/src/screens/LeaderboardScreen.js
+++ b/app/src/screens/LeaderboardScreen.js
@@ -8,6 +8,7 @@ import { db } from '../lib/firebaseConfig';
 import { useTheme } from '../lib/ThemeContext';
 import PropTypes from 'prop-types';
 import { getUserLevel } from '../lib/userLevels';
+import { getSafeSelectedProfileBadge } from '../lib/profileBadges';
 
 export default function LeaderboardScreen({ navigation }) {
     const { theme } = useTheme();
@@ -71,6 +72,9 @@ export default function LeaderboardScreen({ navigation }) {
         const displayName = item.isAnonymous ? 'Anonymous' : item.displayName || 'Anonymous';
         const displayBranch = item.isAnonymous ? 'Hidden' : item.branch || 'Unknown Branch';
         const levelInfo = getUserLevel(item.points || 0);
+        const profileBadge = item.isAnonymous
+            ? null
+            : getSafeSelectedProfileBadge(item.selectedProfileBadge, levelInfo.level);
 
         return (
             <View
@@ -106,6 +110,23 @@ export default function LeaderboardScreen({ navigation }) {
                             Level {levelInfo.level} - {levelInfo.title}
                         </Text>
                     </View>
+                    {profileBadge && (
+                        <View
+                            style={[
+                                styles.profileBadgeRow,
+                                { backgroundColor: profileBadge.color + '18' },
+                            ]}
+                        >
+                            <Ionicons
+                                name={profileBadge.icon}
+                                size={13}
+                                color={profileBadge.color}
+                            />
+                            <Text style={[styles.profileBadgeText, { color: profileBadge.color }]}>
+                                {profileBadge.label}
+                            </Text>
+                        </View>
+                    )}
                 </View>
 
                 <View style={styles.pointsContainer}>
@@ -198,6 +219,17 @@ const styles = StyleSheet.create({
     branch: { fontSize: 12 },
     levelRow: { flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 4 },
     levelText: { fontSize: 11, fontWeight: '700' },
+    profileBadgeRow: {
+        alignSelf: 'flex-start',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 4,
+        marginTop: 6,
+        paddingHorizontal: 8,
+        paddingVertical: 4,
+        borderRadius: 12,
+    },
+    profileBadgeText: { fontSize: 11, fontWeight: '800' },
     pointsContainer: { alignItems: 'flex-end' },
     points: { fontSize: 18, fontWeight: '900' },
     pointsLabel: { fontSize: 10 },

--- a/app/src/screens/ProfileScreen.js
+++ b/app/src/screens/ProfileScreen.js
@@ -2,7 +2,7 @@ import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 // import { Picker } from '@react-native-picker/picker'; // Removed native picker
 import { updateProfile } from 'firebase/auth';
 import { addDoc, collection, doc, getCountFromServer, getDoc, updateDoc } from 'firebase/firestore';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import {
     Alert,
@@ -24,6 +24,12 @@ import { useTheme } from '../lib/ThemeContext';
 import PropTypes from 'prop-types';
 import { LinearGradient } from 'expo-linear-gradient';
 import { getUserLevel, getUserLevelProgress } from '../lib/userLevels';
+import {
+    getSafeSelectedProfileBadge,
+    getUnlockedProfileBadges,
+    PROFILE_BADGES,
+    canUseProfileBadge,
+} from '../lib/profileBadges';
 
 // Helper to get ordinal year labels
 const getYearLabel = y => {
@@ -40,7 +46,6 @@ const getYearLabel = y => {
 };
 
 // Helper for menu items
-
 const MenuItem = ({
     icon,
     label,
@@ -130,6 +135,78 @@ const LevelProgressCard = ({ levelInfo, progressInfo, points, theme, styles }) =
     </View>
 );
 
+const ActiveProfileBadge = ({ badge, onPress, styles }) => (
+    <TouchableOpacity
+        style={[styles.activeProfileBadge, { borderColor: badge.color + '80' }]}
+        onPress={onPress}
+        activeOpacity={0.85}
+    >
+        <View style={[styles.activeProfileBadgeIcon, { backgroundColor: badge.color + '20' }]}>
+            <Ionicons name={badge.icon} size={18} color={badge.color} />
+        </View>
+        <View style={{ flex: 1 }}>
+            <Text style={styles.activeProfileBadgeTitle}>{badge.label}</Text>
+            <Text style={styles.activeProfileBadgeText}>Profile badge</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={18} color={badge.color} />
+    </TouchableOpacity>
+);
+
+const ProfileBadgeShelf = ({
+    badges,
+    selectedBadgeId,
+    onSelectBadge,
+    onManagePress,
+    styles,
+    disabled,
+}) => (
+    <View style={styles.profileBadgeShelf}>
+        <View style={styles.profileBadgeShelfHeader}>
+            <Text style={styles.profileBadgeShelfTitle}>Unlocked badges</Text>
+            <TouchableOpacity onPress={onManagePress} activeOpacity={0.8}>
+                <Text style={styles.profileBadgeShelfAction}>Manage</Text>
+            </TouchableOpacity>
+        </View>
+        <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.profileBadgeShelfList}
+        >
+            {badges.map(badge => {
+                const isSelected = badge.id === selectedBadgeId;
+
+                return (
+                    <TouchableOpacity
+                        key={badge.id}
+                        style={[
+                            styles.profileBadgeShelfItem,
+                            {
+                                borderColor: isSelected ? badge.color : 'transparent',
+                                backgroundColor: badge.color + (isSelected ? '24' : '14'),
+                            },
+                        ]}
+                        onPress={() => onSelectBadge(badge)}
+                        activeOpacity={disabled ? 1 : 0.85}
+                        disabled={disabled}
+                    >
+                        <Ionicons name={badge.icon} size={20} color={badge.color} />
+                        {isSelected && (
+                            <View
+                                style={[
+                                    styles.profileBadgeShelfCheck,
+                                    { backgroundColor: badge.color },
+                                ]}
+                            >
+                                <Ionicons name="checkmark" size={10} color="#fff" />
+                            </View>
+                        )}
+                    </TouchableOpacity>
+                );
+            })}
+        </ScrollView>
+    </View>
+);
+
 LevelProgressCard.propTypes = {
     levelInfo: PropTypes.shape({
         icon: PropTypes.string,
@@ -147,6 +224,31 @@ LevelProgressCard.propTypes = {
     points: PropTypes.number,
     theme: PropTypes.object,
     styles: PropTypes.object,
+};
+
+ActiveProfileBadge.propTypes = {
+    badge: PropTypes.shape({
+        color: PropTypes.string,
+        icon: PropTypes.string,
+        label: PropTypes.string,
+    }),
+    onPress: PropTypes.func,
+    styles: PropTypes.object,
+};
+
+ProfileBadgeShelf.propTypes = {
+    badges: PropTypes.arrayOf(
+        PropTypes.shape({
+            color: PropTypes.string,
+            icon: PropTypes.string,
+            id: PropTypes.string,
+        }),
+    ),
+    selectedBadgeId: PropTypes.string,
+    onSelectBadge: PropTypes.func,
+    onManagePress: PropTypes.func,
+    styles: PropTypes.object,
+    disabled: PropTypes.bool,
 };
 
 const BRANCHES = ['CSE', 'ETC', 'EE', 'ME', 'Civil'];
@@ -168,13 +270,24 @@ export default function ProfileScreen({ navigation }) {
     const [eventsCount, setEventsCount] = useState(0);
     const [rating, setRating] = useState(0);
     const [badges, setBadges] = useState([]);
+    const [selectedProfileBadge, setSelectedProfileBadge] = useState('fresh-face');
     const [isEditing, setIsEditing] = useState(false);
     const [showRequestModal, setShowRequestModal] = useState(false);
+    const [showBadgeModal, setShowBadgeModal] = useState(false);
     const [requestSubject, setRequestSubject] = useState('Request Club Access');
     const [requestMessage, setRequestMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const updatingBadgeRef = useRef(null);
     const levelInfo = useMemo(() => getUserLevel(points), [points]);
     const progressInfo = useMemo(() => getUserLevelProgress(points), [points]);
+    const activeProfileBadge = useMemo(
+        () => getSafeSelectedProfileBadge(selectedProfileBadge, levelInfo.level),
+        [selectedProfileBadge, levelInfo.level],
+    );
+    const unlockedProfileBadges = useMemo(
+        () => getUnlockedProfileBadges(levelInfo.level),
+        [levelInfo.level],
+    );
 
     const fetchUserData = useCallback(async () => {
         if (!user?.uid) return;
@@ -191,6 +304,7 @@ export default function ProfileScreen({ navigation }) {
                 setBranch(data.branch || 'CSE');
                 setPoints(data.points ?? 0);
                 setBadges(data.badges || []);
+                setSelectedProfileBadge(data.selectedProfileBadge || 'fresh-face');
 
                 // Fetch Club Rating (for club/admin users) from reputation field
                 if (role === 'club' || role === 'admin') {
@@ -316,6 +430,41 @@ export default function ProfileScreen({ navigation }) {
         }
     };
 
+    const handleSelectProfileBadge = async badge => {
+        if (loading || updatingBadgeRef.current) return;
+
+        if (badge.id === activeProfileBadge.id) {
+            setShowBadgeModal(false);
+            return;
+        }
+
+        if (!canUseProfileBadge(badge.id, levelInfo.level)) {
+            Alert.alert('Locked Badge', `Reach Level ${badge.requiredLevel} to unlock this badge.`);
+            return;
+        }
+
+        try {
+            updatingBadgeRef.current = badge.id;
+            setLoading(true);
+            await updateDoc(doc(db, 'users', user.uid), {
+                selectedProfileBadge: badge.id,
+            });
+            if (updatingBadgeRef.current !== badge.id) return;
+
+            setSelectedProfileBadge(badge.id);
+            setShowBadgeModal(false);
+            Alert.alert('Badge Updated', `${badge.label} is now shown on your profile.`);
+        } catch (error) {
+            console.error(error);
+            Alert.alert('Error', 'Failed to update profile badge');
+        } finally {
+            if (updatingBadgeRef.current === badge.id) {
+                updatingBadgeRef.current = null;
+                setLoading(false);
+            }
+        }
+    };
+
     return (
         <ScreenWrapper>
             <ScrollView
@@ -370,6 +519,19 @@ export default function ProfileScreen({ navigation }) {
                                 {bio}
                             </Text>
                         ) : null}
+                        <ActiveProfileBadge
+                            badge={activeProfileBadge}
+                            onPress={() => setShowBadgeModal(true)}
+                            styles={styles}
+                        />
+                        <ProfileBadgeShelf
+                            badges={unlockedProfileBadges}
+                            selectedBadgeId={activeProfileBadge.id}
+                            onSelectBadge={handleSelectProfileBadge}
+                            onManagePress={() => setShowBadgeModal(true)}
+                            styles={styles}
+                            disabled={loading}
+                        />
                     </View>
                 </LinearGradient>
 
@@ -782,7 +944,7 @@ export default function ProfileScreen({ navigation }) {
                             </View>
                             <View style={styles.bentoRow}>
                                 <MenuItem
-                                    icon="sparkles-outline"
+                                    icon="trophy-outline"
                                     label="My Wrapped"
                                     description="Your yearly event recap"
                                     width="48%"
@@ -1058,6 +1220,100 @@ export default function ProfileScreen({ navigation }) {
                     </View>
                 </View>
             </Modal>
+
+            <Modal visible={showBadgeModal} transparent animationType="slide">
+                <View style={styles.modalBackdrop}>
+                    <View style={[styles.badgeModal, { backgroundColor: theme.colors.background }]}>
+                        <View style={styles.badgeModalHeader}>
+                            <View>
+                                <Text style={styles.badgeModalTitle}>Choose Profile Badge</Text>
+                                <Text style={styles.badgeModalSubtitle}>
+                                    Level {levelInfo.level} unlocks{' '}
+                                    {
+                                        PROFILE_BADGES.filter(
+                                            badge => badge.requiredLevel <= levelInfo.level,
+                                        ).length
+                                    }{' '}
+                                    badges
+                                </Text>
+                            </View>
+                            <TouchableOpacity
+                                style={styles.badgeModalClose}
+                                onPress={() => setShowBadgeModal(false)}
+                            >
+                                <Ionicons name="close" size={22} color={theme.colors.text} />
+                            </TouchableOpacity>
+                        </View>
+
+                        <ScrollView
+                            contentContainerStyle={styles.profileBadgeGrid}
+                            showsVerticalScrollIndicator={false}
+                        >
+                            {PROFILE_BADGES.map(badge => {
+                                const isUnlocked = canUseProfileBadge(badge.id, levelInfo.level);
+                                const isSelected = activeProfileBadge.id === badge.id;
+
+                                return (
+                                    <TouchableOpacity
+                                        key={badge.id}
+                                        style={[
+                                            styles.profileBadgeOption,
+                                            {
+                                                backgroundColor: theme.colors.surface,
+                                                borderColor: isSelected
+                                                    ? badge.color
+                                                    : theme.colors.border,
+                                                opacity: isUnlocked ? 1 : 0.55,
+                                            },
+                                        ]}
+                                        disabled={!isUnlocked || loading}
+                                        activeOpacity={isUnlocked && !loading ? 0.85 : 1}
+                                        onPress={() => handleSelectProfileBadge(badge)}
+                                    >
+                                        <View
+                                            style={[
+                                                styles.profileBadgeOptionIcon,
+                                                { backgroundColor: badge.color + '20' },
+                                            ]}
+                                        >
+                                            <Ionicons
+                                                name={isUnlocked ? badge.icon : 'lock-closed'}
+                                                size={24}
+                                                color={badge.color}
+                                            />
+                                        </View>
+                                        <View style={{ flex: 1 }}>
+                                            <Text style={styles.profileBadgeOptionTitle}>
+                                                {badge.label}
+                                            </Text>
+                                            <Text style={styles.profileBadgeOptionDescription}>
+                                                {badge.description}
+                                            </Text>
+                                            <Text
+                                                style={[
+                                                    styles.profileBadgeOptionMeta,
+                                                    { color: badge.color },
+                                                ]}
+                                            >
+                                                {isUnlocked
+                                                    ? `Unlocked at Level ${badge.requiredLevel}`
+                                                    : `Unlocks at Level ${badge.requiredLevel}`}
+                                            </Text>
+                                        </View>
+                                        {isSelected && (
+                                            <Ionicons
+                                                name="checkmark-circle"
+                                                size={22}
+                                                color={badge.color}
+                                            />
+                                        )}
+                                    </TouchableOpacity>
+                                );
+                            })}
+                        </ScrollView>
+                    </View>
+                </View>
+            </Modal>
         </ScreenWrapper>
     );
 }
@@ -1143,6 +1399,85 @@ const getStyles = theme =>
             textAlign: 'left',
             color: theme.colors.textSecondary,
             marginTop: 2,
+        },
+        activeProfileBadge: {
+            alignSelf: 'flex-start',
+            minWidth: 210,
+            maxWidth: '100%',
+            flexDirection: 'row',
+            alignItems: 'center',
+            borderWidth: 1.5,
+            borderRadius: 18,
+            paddingVertical: 8,
+            paddingHorizontal: 10,
+            marginTop: 2,
+            backgroundColor: theme.colors.surface,
+            ...theme.shadows.small,
+        },
+        activeProfileBadgeIcon: {
+            width: 34,
+            height: 34,
+            borderRadius: 17,
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginRight: 10,
+        },
+        activeProfileBadgeTitle: {
+            color: theme.colors.text,
+            fontSize: 13,
+            fontWeight: '800',
+        },
+        activeProfileBadgeText: {
+            color: theme.colors.textSecondary,
+            fontSize: 11,
+            marginTop: 1,
+        },
+        profileBadgeShelf: {
+            width: '100%',
+            marginTop: 12,
+            paddingHorizontal: theme.spacing.m,
+        },
+        profileBadgeShelfHeader: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 8,
+        },
+        profileBadgeShelfTitle: {
+            color: theme.colors.textSecondary,
+            fontSize: 12,
+            fontWeight: '800',
+            textTransform: 'uppercase',
+        },
+        profileBadgeShelfAction: {
+            color: theme.colors.primary,
+            fontSize: 12,
+            fontWeight: '800',
+        },
+        profileBadgeShelfList: {
+            gap: 8,
+            paddingRight: theme.spacing.m,
+        },
+        profileBadgeShelfItem: {
+            width: 42,
+            height: 42,
+            borderRadius: 21,
+            borderWidth: 1.5,
+            alignItems: 'center',
+            justifyContent: 'center',
+            position: 'relative',
+        },
+        profileBadgeShelfCheck: {
+            position: 'absolute',
+            right: -2,
+            bottom: -2,
+            width: 16,
+            height: 16,
+            borderRadius: 8,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderWidth: 1.5,
+            borderColor: theme.colors.background,
         },
         editIconBtn: {
             backgroundColor: theme.colors.primary + '20',
@@ -1385,6 +1720,75 @@ const getStyles = theme =>
         badgeText: {
             fontSize: 12,
             fontWeight: 'bold',
+        },
+        modalBackdrop: {
+            flex: 1,
+            backgroundColor: 'rgba(0,0,0,0.55)',
+            justifyContent: 'flex-end',
+        },
+        badgeModal: {
+            maxHeight: '82%',
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+            padding: 20,
+        },
+        badgeModalHeader: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 16,
+        },
+        badgeModalTitle: {
+            color: theme.colors.text,
+            fontSize: 20,
+            fontWeight: '900',
+        },
+        badgeModalSubtitle: {
+            color: theme.colors.textSecondary,
+            fontSize: 12,
+            marginTop: 4,
+        },
+        badgeModalClose: {
+            width: 38,
+            height: 38,
+            borderRadius: 19,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.colors.surface,
+        },
+        profileBadgeGrid: {
+            paddingBottom: 24,
+            gap: 10,
+        },
+        profileBadgeOption: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            borderWidth: 1.5,
+            borderRadius: 16,
+            padding: 12,
+        },
+        profileBadgeOptionIcon: {
+            width: 48,
+            height: 48,
+            borderRadius: 16,
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginRight: 12,
+        },
+        profileBadgeOptionTitle: {
+            color: theme.colors.text,
+            fontSize: 15,
+            fontWeight: '800',
+        },
+        profileBadgeOptionDescription: {
+            color: theme.colors.textSecondary,
+            fontSize: 12,
+            marginTop: 2,
+        },
+        profileBadgeOptionMeta: {
+            fontSize: 11,
+            fontWeight: '800',
+            marginTop: 5,
         },
 
         formActions: {

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -825,9 +825,6 @@ const styles = StyleSheet.create({
         marginLeft: 10,
         fontSize: 16,
         borderWidth: 0,
-        ...Platform.select({
-            web: { outlineStyle: 'none' },
-        }),
     },
     filterWrapper: {
         height: 60,


### PR DESCRIPTION
Closes Issue number #210
## Summary
- Added level-based multiple profile badges metadata and unlock logic to select from.
- Added a selected profile badge on the Profile screen.
- Added an unlocked badge shelf and badge picker modal.
- Displayed selected public badges on leaderboard rows.
- Hid profile badges for anonymous leaderboard users.
- Removed invalid native TextInput outlineStyle warnings for cleaner mobile testing.

## Testing
- npm test -- --runInBand src/lib/__tests__/profileBadges.test.js --coverage=false
- npm run lint

## Screenshots
- LeaderBoard
<img width="650" height="736" alt="image" src="https://github.com/user-attachments/assets/f74e064f-3835-4ff3-9eb7-6bf85b430e01" />

- Profile 
<img width="1632" height="1570" alt="image" src="https://github.com/user-attachments/assets/92de5c14-94ec-44da-ad06-c5c6f2f5d04a" />

- Selecting Badges (With Locked badges)
<img width="387" height="764" alt="Screenshot 2026-05-26 at 10 00 10 PM" src="https://github.com/user-attachments/assets/d803b750-ec02-4c7c-a444-a05c74dccd8b" />

- Selecting Badges (With all Unlocked badges)
<img width="381" height="642" alt="Screenshot 2026-05-26 at 10 02 08 PM" src="https://github.com/user-attachments/assets/8f8c5dd6-8e9d-4a0d-b7e5-6efd11172ddf" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a profile badge system with unlockable badges by user level.
  * Users can select and display an active profile badge on their profile.
  * Profile badges now appear on leaderboard entries.
  * New badge chooser modal with locked/unlocked visuals and selection indicator.
  * Activity menu icon updated to a trophy symbol.

* **Tests**
  * Added comprehensive tests for badge lookup, unlocking, defaults, uniqueness, and icon/label validity.

* **Style**
  * Refined input field styling across screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->