### PR TITLE
fix(chat): restrict event chat access to participants

### DIFF
--- a/app/src/screens/EventChatScreen.js
+++ b/app/src/screens/EventChatScreen.js
@@ -48,28 +48,53 @@ export default function EventChatScreen({ route, navigation }) {
     // Check if user is organizer/admin to show badge
     const [isOrganizer, setIsOrganizer] = useState(false);
 
+
     useEffect(() => {
         let unsubscribeMessages;
+        let isActive = true;
 
         const checkAccessAndSubscribe = async () => {
             if (!user?.uid) {
+                if (!isActive) return;
+
+                setIsOrganizer(false);
                 setHasAccess(false);
                 setCheckingAccess(false);
                 return;
             }
 
             try {
-                setCheckingAccess(true);
+                if (isActive) setCheckingAccess(true);
 
                 const eventDoc = await getDoc(doc(db, 'events', eventId));
-                const isOwner = eventDoc.exists() && eventDoc.data().ownerId === user.uid;
-                const isAdminOrClub = role === 'admin' || role === 'club';
+
+                if (!isActive) return;
+
+                const isOwner =
+                    eventDoc.exists() && eventDoc.data().ownerId === user.uid;
+
+                const isAdmin = role === 'admin';
 
                 const participantDoc = await getDoc(
                     doc(db, 'events', eventId, 'participants', user.uid),
                 );
 
-                const allowed = participantDoc.exists() || isOwner || isAdminOrClub;
+                if (!isActive) return;
+
+                const participantData = participantDoc.exists()
+                    ? participantDoc.data()
+                    : null;
+
+                const eventScopedClubStaff =
+                    participantDoc.exists() &&
+                    (participantData?.role === 'club' ||
+                        participantData?.isStaff === true);
+
+                const allowed =
+                    participantDoc.exists() ||
+                    isOwner ||
+                    isAdmin ||
+                    eventScopedClubStaff;
 
                 setIsOrganizer(isOwner);
                 setHasAccess(allowed);
@@ -84,7 +109,9 @@ export default function EventChatScreen({ route, navigation }) {
                     orderBy('createdAt', 'desc'),
                 );
 
-                unsubscribeMessages = onSnapshot(q, snapshot => {
+                const localUnsub = onSnapshot(q, snapshot => {
+                    if (!isActive) return;
+
                     setMessages(
                         snapshot.docs.map(doc => ({
                             id: doc.id,
@@ -92,21 +119,34 @@ export default function EventChatScreen({ route, navigation }) {
                         })),
                     );
                 });
+
+                unsubscribeMessages = localUnsub;
             } catch (error) {
                 console.error('Access check failed', error);
+
+                if (!isActive) return;
+
                 setHasAccess(false);
                 setMessages([]);
             } finally {
-                setCheckingAccess(false);
+                if (isActive) {
+                    setCheckingAccess(false);
+                }
             }
         };
 
         checkAccessAndSubscribe();
 
         return () => {
-            if (unsubscribeMessages) unsubscribeMessages();
+            isActive = false;
+
+            if (unsubscribeMessages) {
+                unsubscribeMessages();
+            }
         };
     }, [eventId, user?.uid, role]);
+
+
 
     const handleSend = async () => {
         if (!inputText.trim() || !user?.uid || !hasAccess) return;
@@ -183,9 +223,9 @@ export default function EventChatScreen({ route, navigation }) {
                     >
                         {item.createdAt?.toMillis
                             ? new Date(item.createdAt.toMillis()).toLocaleTimeString([], {
-                                  hour: '2-digit',
-                                  minute: '2-digit',
-                              })
+                                hour: '2-digit',
+                                minute: '2-digit',
+                            })
                             : 'Just now'}
                     </Text>
                 </View>

--- a/app/src/screens/EventChatScreen.js
+++ b/app/src/screens/EventChatScreen.js
@@ -36,6 +36,8 @@ export default function EventChatScreen({ route, navigation }) {
     const [inputText, setInputText] = useState('');
     const [sending, setSending] = useState(false);
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+    const [hasAccess, setHasAccess] = useState(false);
+    const [checkingAccess, setCheckingAccess] = useState(true);
 
     const emojis = ['👍', '❤️', '😂', '😮', '😢', '😡', '🔥', '🎉', '👋', '🙏', '💯', '👀'];
 
@@ -47,41 +49,67 @@ export default function EventChatScreen({ route, navigation }) {
     const [isOrganizer, setIsOrganizer] = useState(false);
 
     useEffect(() => {
-        // Check organizer status
-        const checkOwner = async () => {
+        let unsubscribeMessages;
+
+        const checkAccessAndSubscribe = async () => {
             if (!user?.uid) {
-                setIsOrganizer(false);
+                setHasAccess(false);
+                setCheckingAccess(false);
                 return;
             }
-            const eventDoc = await getDoc(doc(db, 'events', eventId));
-            if (eventDoc.exists() && eventDoc.data().ownerId === user.uid) {
-                setIsOrganizer(true);
-            } else {
-                setIsOrganizer(false);
+
+            try {
+                setCheckingAccess(true);
+
+                const eventDoc = await getDoc(doc(db, 'events', eventId));
+                const isOwner = eventDoc.exists() && eventDoc.data().ownerId === user.uid;
+                const isAdminOrClub = role === 'admin' || role === 'club';
+
+                const participantDoc = await getDoc(
+                    doc(db, 'events', eventId, 'participants', user.uid),
+                );
+
+                const allowed = participantDoc.exists() || isOwner || isAdminOrClub;
+
+                setIsOrganizer(isOwner);
+                setHasAccess(allowed);
+
+                if (!allowed) {
+                    setMessages([]);
+                    return;
+                }
+
+                const q = query(
+                    collection(db, 'events', eventId, 'messages'),
+                    orderBy('createdAt', 'desc'),
+                );
+
+                unsubscribeMessages = onSnapshot(q, snapshot => {
+                    setMessages(
+                        snapshot.docs.map(doc => ({
+                            id: doc.id,
+                            ...doc.data(),
+                        })),
+                    );
+                });
+            } catch (error) {
+                console.error('Access check failed', error);
+                setHasAccess(false);
+                setMessages([]);
+            } finally {
+                setCheckingAccess(false);
             }
         };
-        checkOwner();
 
-        // Subscribe to messages
-        const q = query(
-            collection(db, 'events', eventId, 'messages'),
-            orderBy('createdAt', 'desc'),
-        );
+        checkAccessAndSubscribe();
 
-        const unsubscribe = onSnapshot(q, snapshot => {
-            setMessages(
-                snapshot.docs.map(doc => ({
-                    id: doc.id,
-                    ...doc.data(),
-                })),
-            );
-        });
-
-        return () => unsubscribe();
-    }, [eventId, user?.uid]);
+        return () => {
+            if (unsubscribeMessages) unsubscribeMessages();
+        };
+    }, [eventId, user?.uid, role]);
 
     const handleSend = async () => {
-        if (!inputText.trim()) return;
+        if (!inputText.trim() || !user?.uid || !hasAccess) return;
         setSending(true);
         try {
             await addDoc(collection(db, 'events', eventId, 'messages'), {
@@ -164,6 +192,42 @@ export default function EventChatScreen({ route, navigation }) {
             </View>
         );
     };
+
+    if (checkingAccess) {
+        return (
+            <SafeAreaView
+                style={[styles.centerContainer, { backgroundColor: theme.colors.background }]}
+            >
+                <ActivityIndicator size="large" color={theme.colors.primary} />
+                <Text style={[styles.accessText, { color: theme.colors.textSecondary }]}>
+                    Checking chat access...
+                </Text>
+            </SafeAreaView>
+        );
+    }
+
+    if (!hasAccess) {
+        return (
+            <SafeAreaView
+                style={[styles.centerContainer, { backgroundColor: theme.colors.background }]}
+            >
+                <Ionicons name="lock-closed" size={56} color={theme.colors.textSecondary} />
+                <Text style={[styles.accessTitle, { color: theme.colors.text }]}>
+                    Chat Access Restricted
+                </Text>
+                <Text style={[styles.accessText, { color: theme.colors.textSecondary }]}>
+                    You must register for this event to access the chat.
+                </Text>
+
+                <TouchableOpacity
+                    style={[styles.backAccessBtn, { backgroundColor: theme.colors.primary }]}
+                    onPress={() => navigation.goBack()}
+                >
+                    <Text style={styles.backAccessText}>Go Back</Text>
+                </TouchableOpacity>
+            </SafeAreaView>
+        );
+    }
 
     return (
         <SafeAreaView
@@ -282,6 +346,34 @@ export default function EventChatScreen({ route, navigation }) {
 }
 
 const styles = StyleSheet.create({
+    centerContainer: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 24,
+    },
+    accessTitle: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        marginTop: 16,
+        textAlign: 'center',
+    },
+    accessText: {
+        fontSize: 14,
+        marginTop: 8,
+        textAlign: 'center',
+        lineHeight: 20,
+    },
+    backAccessBtn: {
+        marginTop: 20,
+        paddingHorizontal: 22,
+        paddingVertical: 12,
+        borderRadius: 10,
+    },
+    backAccessText: {
+        color: '#fff',
+        fontWeight: 'bold',
+    },
     container: { flex: 1 },
     header: {
         flexDirection: 'row',


### PR DESCRIPTION
# Description

Added participant-based access control for event chat functionality.

This update prevents unauthorized users from accessing event chats by validating participation status before subscribing to Firestore chat listeners or allowing message sending.

Fixes #311

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

# How Has This Been Tested?

* Verified registered participants can access event chat successfully

* Verified non-participants receive a restricted access screen

* Verified organizers/admins retain chat access

* Tested message sending restrictions for unauthorized users

* Tested Firestore listener cleanup and access validation flow

* [x] Test A

* [x] Test B

# Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now verifies user permissions (owner/admin/participant/club staff) before showing or allowing messages.
  * Shows a loading state while checking access; presents a restricted screen with a lock and “Go Back” if unauthorized.
  * Stops message delivery and sending if access is denied or revoked.

* **Style**
  * Updated layouts, typography, and button styles for loading and access-restricted views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->