### PR TITLE
fix: validate Instagram and LinkedIn URLs before saving to Firestore

### DIFF
--- a/app/src/screens/ProfileScreen.js
+++ b/app/src/screens/ProfileScreen.js
@@ -343,6 +343,15 @@ export default function ProfileScreen({ navigation }) {
 
     const handleSave = async () => {
         if (!name) return Alert.alert('Error', 'Name cannot be empty');
+
+        const urlPattern = /^https?:\/\/.+/;
+        if (instagram && !urlPattern.test(instagram.trim())) {
+            return Alert.alert('Invalid URL', 'Instagram link must start with https://');
+        }
+        if (linkedin && !urlPattern.test(linkedin.trim())) {
+            return Alert.alert('Invalid URL', 'LinkedIn link must start with https://');
+        }
+
         setLoading(true);
         try {
             await updateProfile(user, { displayName: name });

--- a/app/src/screens/ProfileScreen.js
+++ b/app/src/screens/ProfileScreen.js
@@ -344,11 +344,13 @@ export default function ProfileScreen({ navigation }) {
     const handleSave = async () => {
         if (!name) return Alert.alert('Error', 'Name cannot be empty');
 
-        const urlPattern = /^https?:\/\/.+/;
-        if (instagram && !urlPattern.test(instagram.trim())) {
+        const trimmedInstagram = instagram.trim();
+        const trimmedLinkedin = linkedin.trim();
+        const urlPattern = /^https:\/\/.+/;
+        if (trimmedInstagram && !urlPattern.test(trimmedInstagram)) {
             return Alert.alert('Invalid URL', 'Instagram link must start with https://');
         }
-        if (linkedin && !urlPattern.test(linkedin.trim())) {
+        if (trimmedLinkedin && !urlPattern.test(trimmedLinkedin)) {
             return Alert.alert('Invalid URL', 'LinkedIn link must start with https://');
         }
 


### PR DESCRIPTION
## Description
The profile editor accepted any text input for social media links with no validation. Invalid or broken links were silently saved to Firestore and displayed as tappable links on user profiles, causing crashes or blank pages when opened.

The fix adds a URL format check inside `handleSave` in `ProfileScreen.js`, immediately after the existing name validation and before the Firestore write is triggered.

Closes #299

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Test A — Empty fields are still allowed (social links are optional)
- [x] Test B — Text like `abcd123` is rejected with an Alert before saving
- [x] Test C — Valid URLs like `https://instagram.com/profile` pass through correctly

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile save now trims Instagram and LinkedIn inputs and requires URLs to start with "https://". If a social link is invalid, saving is stopped and an alert explains which field is invalid; valid inputs proceed and update the profile.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->