### PR TITLE
fix: resolve IDOR vulnerability in storage rules

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -21,7 +21,9 @@ service firebase.storage {
     match /events/{eventId}/{file=**}{
       allow read: if true;
       allow write: if request.auth != null
-                   && (request.auth.token.admin == true || request.auth.token.club == true)
+                   && (request.auth.token.admin == true || 
+                       (request.auth.token.club == true && 
+                        request.auth.uid == firestore.get(/databases/(default)/documents/events/$(eventId)).data.ownerId))
                    && request.resource.size < 5*1024*1024
                    && request.resource.contentType.matches('image/(jpeg|png|webp)');
     }

--- a/storage.rules
+++ b/storage.rules
@@ -23,6 +23,7 @@ service firebase.storage {
       allow write: if request.auth != null
                    && (request.auth.token.admin == true || 
                        (request.auth.token.club == true && 
+                        firestore.exists(/databases/(default)/documents/events/$(eventId)) &&
                         request.auth.uid == firestore.get(/databases/(default)/documents/events/$(eventId)).data.ownerId))
                    && request.resource.size < 5*1024*1024
                    && request.resource.contentType.matches('image/(jpeg|png|webp)');


### PR DESCRIPTION
Closes #364

Updated storage rules to check event ownership using firestore cross-service rules. Now, club users can only write to storage paths for events they actually own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened event file upload permissions: only authenticated event owners, administrators, or authorized club accounts explicitly linked to the event owner can upload files, and uploads are blocked unless the referenced event exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->