### PR TITLE
fix: store free event price as number instead of string

### DIFF
--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -276,7 +276,7 @@ export default function CreateEvent({ navigation, route }) {
                 startAt: startDate.toISOString(),
                 endAt: endDate.toISOString(),
                 isPaid,
-                price: isPaid ? price : '0',
+                price: isPaid ? Math.max(0, parseFloat(price) || 0) : 0,
                 upiId: isPaid ? upiId : null,
                 registrationLink,
                 target: {

--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -276,7 +276,7 @@ export default function CreateEvent({ navigation, route }) {
                 startAt: startDate.toISOString(),
                 endAt: endDate.toISOString(),
                 isPaid,
-                price: isPaid ? Math.max(0, parseFloat(price) || 0) : 0,
+                price: isPaid ? Math.max(0, Number.parseFloat(price) || 0) : 0,
                 upiId: isPaid ? upiId : null,
                 registrationLink,
                 target: {

--- a/app/src/screens/EventDetail.js
+++ b/app/src/screens/EventDetail.js
@@ -1006,7 +1006,7 @@ export default function EventDetail({ route, navigation }) {
         const isExpired = deadline && new Date() > deadline;
         const isEarlyBirdTicket =
             ticket.isEarlyBird || (ticket.name && ticket.name.toLowerCase().includes('early'));
-        const isFree = !ticket.price || ticket.price === 0;
+        const isFree = !ticket.price || Number(ticket.price) <= 0;
         const accentColor = isEarlyBirdTicket ? '#EAB308' : theme.colors.primary;
         const benefitsOpen = expandedBenefits.has(idx);
         const hasBenefits = ticket.benefits && ticket.benefits.length > 0;


### PR DESCRIPTION
## Description
When an organiser creates a free event, the price was being written to 
Firestore as the string "0" instead of the number 0. The free-ticket 
check in EventDetail.js uses strict equality against the number 0, which 
fails for the string "0". As a result, free events incorrectly displayed 
₹0 in the ticket UI instead of showing "Free".

Closes #300

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Test A — Free event now stores price as number 0 in Firestore, not string "0"
- [x] Test B — isFree check uses Number(ticket.price) <= 0 to handle both 
existing string values and new numeric values
- [x] Test C — Negative prices are floored to 0 using Math.max(0, ...) 
to prevent invalid data

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures event price is stored as a numeric value (non-negative) for paid events and as numeric 0 for free events.
  * Improves detection of free tickets by treating values ≤ 0 as complimentary.
  * Increases consistency and reliability of pricing display and event/ticket classification across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->