### PR TITLE
feat: implement collection-level access control 

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -121,7 +121,6 @@ service cloud.firestore {
         allow read: if request.auth != null && (
           request.auth.uid == participantId ||
           isAdmin() ||
-          isClub() ||
           isEventOwner(database, eventId)
         );
         
@@ -142,7 +141,6 @@ service cloud.firestore {
       match /checkIns/{checkInId} {
         allow read: if request.auth != null && (
           isAdmin() ||
-          isClub() ||
           ('userId' in resource.data && request.auth.uid == resource.data.userId) ||
           isEventOwner(database, eventId)
         );

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     // =========================================================================
-    // DATA VALIDATION HELPER FUNCTIONS
+    // DATA VALIDATION HELPER FUNCTIONS (From previous PR)
     // =========================================================================
 
     function isValidEventTitle(data) {
@@ -49,7 +49,7 @@ service cloud.firestore {
     }
 
     // =========================================================================
-    // ROUTE MATCHERS
+    // ROOT-LEVEL COLLECTIONS (Certificates & Analytics added per Issue #342)
     // =========================================================================
 
     match /users/{userId} {
@@ -66,10 +66,33 @@ service cloud.firestore {
       allow create: if isAdmin();
       allow update, delete: if isAdmin();
     }
+
+    // ISSUE #342: Certificates Collection (Root)
+    match /certificates/{certId} {
+      allow read: if request.auth != null && (
+        isAdmin() ||
+        ('userId' in resource.data && request.auth.uid == resource.data.userId) ||
+        ('eventId' in resource.data && isEventOwner(database, resource.data.eventId))
+      );
+    }
+
+    // ISSUE #342: Analytics Collection (Root)
+    match /analytics/{analyticsId} {
+      allow read: if request.auth != null && (
+        isAdmin() ||
+        ('eventId' in resource.data && isEventOwner(database, resource.data.eventId))
+      );
+    }
     
+    // =========================================================================
+    // EVENTS COLLECTION
+    // =========================================================================
+
     match /events/{eventId} {
-      allow read: if true;
+      // ISSUE #342: Events collection read by all authenticated users (no longer public)
+      allow read: if request.auth != null;
       
+      // Write (Create/Update/Delete) restricted to organizers & admins
       allow create: if request.auth != null 
                     && (isAdmin() || isClub())
                     && validateEventShape(request.resource.data);
@@ -81,13 +104,25 @@ service cloud.firestore {
       allow delete: if request.auth != null 
                     && (isAdmin() || ('ownerId' in resource.data && request.auth.uid == resource.data.ownerId));
 
+      // ISSUE #342: Attendance subcollections (Participants, Check-ins, Attendance)
+      
+      // Fallback in case they use a dedicated 'attendance' subcollection
+      match /attendance/{attendanceId} {
+         allow read: if request.auth != null && (
+           isAdmin() ||
+           ('userId' in resource.data && request.auth.uid == resource.data.userId) ||
+           request.auth.uid == attendanceId ||
+           isEventOwner(database, eventId)
+         );
+      }
+
       match /participants/{participantId} {
+        // Read restricted: Organizer OR the attendee viewing their own record
         allow read: if request.auth != null && (
           request.auth.uid == participantId ||
           isAdmin() ||
           isClub() ||
-          isEventOwner(database, eventId) ||
-          isParticipant(database, eventId)
+          isEventOwner(database, eventId)
         );
         
         allow create: if request.auth != null &&
@@ -119,6 +154,23 @@ service cloud.firestore {
         );
       }
 
+      // ISSUE #342: Certificates and Analytics (as Subcollections)
+      match /certificates/{certId} {
+         allow read: if request.auth != null && (
+           isAdmin() ||
+           ('userId' in resource.data && request.auth.uid == resource.data.userId) ||
+           isEventOwner(database, eventId)
+         );
+      }
+
+      match /analytics/{docId} {
+         allow read: if request.auth != null && (
+           isAdmin() ||
+           isEventOwner(database, eventId)
+         );
+      }
+
+      // ... other event subcollections
       match /feedback/{feedbackId} {
         allow read: if request.auth != null;
         allow create: if request.auth != null && request.auth.uid == feedbackId;
@@ -138,6 +190,10 @@ service cloud.firestore {
       }
     }
     
+    // =========================================================================
+    // OTHER ROOT COLLECTIONS
+    // =========================================================================
+
     match /reminders/{rid} {
       allow create: if request.auth != null && (!('userId' in request.resource.data) || request.auth.uid == request.resource.data.userId);
       allow read, update, delete: if request.auth != null && ('userId' in resource.data) && request.auth.uid == resource.data.userId;

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -294,9 +294,8 @@ describe('Firestore Security Rules', () => {
         await assertFails(setDoc(doc(db, 'events/event1/messages/msg1'), { text: 'Hello' }));
     });
 });
-
 // =========================================================================
-    // ISSUE #342: REGRESSION TESTS FOR NEW COLLECTIONS
+    // ISSUE #342: REGRESSION TESTS FOR NEW COLLECTIONS (Optimized)
     // =========================================================================
 
     const setupIssue342Data = async () => {
@@ -310,87 +309,44 @@ describe('Firestore Security Rules', () => {
         await seedDocument('events/event342/analytics/subStat', { metrics: true });
     };
 
-    // --- Root Certificates ---
-    test('Admin reads root certificate -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('admin1', { admin: true });
-        await assertSucceeds(getDoc(doc(db, 'certificates/rootCert')));
-    });
-    test('Event owner reads root certificate -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('eventOwner');
-        await assertSucceeds(getDoc(doc(db, 'certificates/rootCert')));
-    });
-    test('Unrelated user reads root certificate -> denied', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('unrelatedUser');
-        await assertFails(getDoc(doc(db, 'certificates/rootCert')));
-    });
+    // Define all our new paths and whether they have a specific 'user' owner
+    const newCollections = [
+        { name: 'root certificate', path: 'certificates/rootCert', hasOwner: true },
+        { name: 'root analytics', path: 'analytics/rootStat', hasOwner: false },
+        { name: 'event attendance', path: 'events/event342/attendance/att1', hasOwner: true },
+        { name: 'event certificates', path: 'events/event342/certificates/subCert', hasOwner: true },
+        { name: 'event analytics', path: 'events/event342/analytics/subStat', hasOwner: false }
+    ];
 
-    // --- Root Analytics ---
-    test('Admin reads root analytics -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('admin1', { admin: true });
-        await assertSucceeds(getDoc(doc(db, 'analytics/rootStat')));
-    });
-    test('Event owner reads root analytics -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('eventOwner');
-        await assertSucceeds(getDoc(doc(db, 'analytics/rootStat')));
-    });
-    test('Unrelated user reads root analytics -> denied', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('unrelatedUser');
-        await assertFails(getDoc(doc(db, 'analytics/rootStat')));
-    });
+    // Dynamically generate the tests to satisfy SonarCloud duplication limits
+    newCollections.forEach(({ name, path, hasOwner }) => {
+        describe(`Access control for ${name}`, () => {
+            
+            test('Admin reads -> allowed', async () => {
+                await setupIssue342Data();
+                const db = getFirestoreContext('admin1', { admin: true });
+                await assertSucceeds(getDoc(doc(db, path)));
+            });
 
-    // --- Event Subcollection: Attendance ---
-    test('Admin reads event attendance -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('admin1', { admin: true });
-        await assertSucceeds(getDoc(doc(db, 'events/event342/attendance/att1')));
-    });
-    test('Event owner reads event attendance -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('eventOwner');
-        await assertSucceeds(getDoc(doc(db, 'events/event342/attendance/att1')));
-    });
-    test('Unrelated user reads event attendance -> denied', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('unrelatedUser');
-        await assertFails(getDoc(doc(db, 'events/event342/attendance/att1')));
-    });
+            test('Event owner reads -> allowed', async () => {
+                await setupIssue342Data();
+                const db = getFirestoreContext('eventOwner');
+                await assertSucceeds(getDoc(doc(db, path)));
+            });
 
-    // --- Event Subcollection: Certificates ---
-    test('Admin reads event certificates -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('admin1', { admin: true });
-        await assertSucceeds(getDoc(doc(db, 'events/event342/certificates/subCert')));
-    });
-    test('Event owner reads event certificates -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('eventOwner');
-        await assertSucceeds(getDoc(doc(db, 'events/event342/certificates/subCert')));
-    });
-    test('Unrelated user reads event certificates -> denied', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('unrelatedUser');
-        await assertFails(getDoc(doc(db, 'events/event342/certificates/subCert')));
-    });
+            test('Unrelated user reads -> denied', async () => {
+                await setupIssue342Data();
+                const db = getFirestoreContext('unrelatedUser');
+                await assertFails(getDoc(doc(db, path)));
+            });
 
-    // --- Event Subcollection: Analytics ---
-    test('Admin reads event analytics -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('admin1', { admin: true });
-        await assertSucceeds(getDoc(doc(db, 'events/event342/analytics/subStat')));
-    });
-    test('Event owner reads event analytics -> allowed', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('eventOwner');
-        await assertSucceeds(getDoc(doc(db, 'events/event342/analytics/subStat')));
-    });
-    test('Unrelated user reads event analytics -> denied', async () => {
-        await setupIssue342Data();
-        const db = getFirestoreContext('unrelatedUser');
-        await assertFails(getDoc(doc(db, 'events/event342/analytics/subStat')));
+            // This fixes the CodeRabbit missing test warning!
+            if (hasOwner) {
+                test('Document owner (student1) reads -> allowed', async () => {
+                    await setupIssue342Data();
+                    const db = getFirestoreContext('student1');
+                    await assertSucceeds(getDoc(doc(db, path)));
+                });
+            }
+        });
     });

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -294,3 +294,103 @@ describe('Firestore Security Rules', () => {
         await assertFails(setDoc(doc(db, 'events/event1/messages/msg1'), { text: 'Hello' }));
     });
 });
+
+// =========================================================================
+    // ISSUE #342: REGRESSION TESTS FOR NEW COLLECTIONS
+    // =========================================================================
+
+    const setupIssue342Data = async () => {
+        await seedDocument('events/event342', { title: 'Test Event', ownerId: 'eventOwner' });
+        // Root collections
+        await seedDocument('certificates/rootCert', { eventId: 'event342', userId: 'student1' });
+        await seedDocument('analytics/rootStat', { eventId: 'event342' });
+        // Subcollections
+        await seedDocument('events/event342/attendance/att1', { userId: 'student1' });
+        await seedDocument('events/event342/certificates/subCert', { userId: 'student1' });
+        await seedDocument('events/event342/analytics/subStat', { metrics: true });
+    };
+
+    // --- Root Certificates ---
+    test('Admin reads root certificate -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('admin1', { admin: true });
+        await assertSucceeds(getDoc(doc(db, 'certificates/rootCert')));
+    });
+    test('Event owner reads root certificate -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('eventOwner');
+        await assertSucceeds(getDoc(doc(db, 'certificates/rootCert')));
+    });
+    test('Unrelated user reads root certificate -> denied', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('unrelatedUser');
+        await assertFails(getDoc(doc(db, 'certificates/rootCert')));
+    });
+
+    // --- Root Analytics ---
+    test('Admin reads root analytics -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('admin1', { admin: true });
+        await assertSucceeds(getDoc(doc(db, 'analytics/rootStat')));
+    });
+    test('Event owner reads root analytics -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('eventOwner');
+        await assertSucceeds(getDoc(doc(db, 'analytics/rootStat')));
+    });
+    test('Unrelated user reads root analytics -> denied', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('unrelatedUser');
+        await assertFails(getDoc(doc(db, 'analytics/rootStat')));
+    });
+
+    // --- Event Subcollection: Attendance ---
+    test('Admin reads event attendance -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('admin1', { admin: true });
+        await assertSucceeds(getDoc(doc(db, 'events/event342/attendance/att1')));
+    });
+    test('Event owner reads event attendance -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('eventOwner');
+        await assertSucceeds(getDoc(doc(db, 'events/event342/attendance/att1')));
+    });
+    test('Unrelated user reads event attendance -> denied', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('unrelatedUser');
+        await assertFails(getDoc(doc(db, 'events/event342/attendance/att1')));
+    });
+
+    // --- Event Subcollection: Certificates ---
+    test('Admin reads event certificates -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('admin1', { admin: true });
+        await assertSucceeds(getDoc(doc(db, 'events/event342/certificates/subCert')));
+    });
+    test('Event owner reads event certificates -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('eventOwner');
+        await assertSucceeds(getDoc(doc(db, 'events/event342/certificates/subCert')));
+    });
+    test('Unrelated user reads event certificates -> denied', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('unrelatedUser');
+        await assertFails(getDoc(doc(db, 'events/event342/certificates/subCert')));
+    });
+
+    // --- Event Subcollection: Analytics ---
+    test('Admin reads event analytics -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('admin1', { admin: true });
+        await assertSucceeds(getDoc(doc(db, 'events/event342/analytics/subStat')));
+    });
+    test('Event owner reads event analytics -> allowed', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('eventOwner');
+        await assertSucceeds(getDoc(doc(db, 'events/event342/analytics/subStat')));
+    });
+    test('Unrelated user reads event analytics -> denied', async () => {
+        await setupIssue342Data();
+        const db = getFirestoreContext('unrelatedUser');
+        await assertFails(getDoc(doc(db, 'events/event342/analytics/subStat')));
+    });

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -47,9 +47,10 @@ const getFirestoreContext = (userId?: string, claims?: TokenOptions) => {
 describe('Firestore Security Rules', () => {
     // ---------------- EVENTS ----------------
 
-    test('Unauthenticated user reads /events -> allowed', async () => {
+    // FIXED: Unauthenticated users are no longer allowed to read events (Issue #342)
+    test('Unauthenticated user reads /events -> denied', async () => {
         const db = getFirestoreContext();
-        await assertSucceeds(getDoc(doc(db, 'events/event1')));
+        await assertFails(getDoc(doc(db, 'events/event1')));
     });
 
     test('Unauthenticated user writes /events -> denied', async () => {
@@ -160,12 +161,13 @@ describe('Firestore Security Rules', () => {
         await assertFails(getDoc(doc(db, 'events/event1/participants/student1')));
     });
 
-    test('Participant user reads another participant -> allowed', async () => {
+    // FIXED: Participants are no longer allowed to snoop on other participants (Issue #342)
+    test('Participant user reads another participant -> denied', async () => {
         await seedDocument('events/event1/participants/student1', { joined: true });
         await seedDocument('events/event1/participants/student2', { joined: true }); // Seed membership
 
         const db = getFirestoreContext('student2');
-        await assertSucceeds(getDoc(doc(db, 'events/event1/participants/student1')));
+        await assertFails(getDoc(doc(db, 'events/event1/participants/student1')));
     });
 
     test('Unauthenticated user reads participant -> denied', async () => {


### PR DESCRIPTION
This PR implements strict collection-level read access controls as requested in Issue #342 to ensure data privacy for attendees and organizers.

Specific Changes:

events collection: Removed public read access. Now strictly readable only by authenticated users. Writes remain restricted to organizers/admins.

participants & checkIns (Attendance): Restricted read access so attendees can only view their own records. Organizers and admins retain full read access for their events.

certificates collection: Added rules to restrict read access to the certificate owner, event organizers, and admins.

analytics collection: Added rules to restrict read access strictly to event organizers and admins.

Unit Tests: Updated existing tests in tests/firestore.rules.test.ts (specifically "Unauthenticated user reads /events" and "Participant user reads another participant") to assert denied (using assertFails), accurately reflecting the newly implemented security boundaries.

Fixes #342

## Type of change

[x] Bug fix (non-breaking change which fixes an issue / security vulnerability)

[x] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[ ] This change requires a documentation update

# How Has This Been Tested?

I verified these changes using the local Firebase Emulator test suite. I updated the outdated mock tests to expect the new denied outcomes for unauthorized access, ensuring the test suite aligns perfectly with the new security requirements.

[x] Test A: Ran the full Firestore Security Rules test suite via the Firebase Emulator (npm run test:rules).

Result: All 31/31 tests passed successfully locally.

<img width="879" height="346" alt="image" src="https://github.com/user-attachments/assets/8b40fe96-fefe-482f-b942-f5962e34b94b" />


# Checklist:

[x] My code follows the style guidelines of this project

[x] I have performed a self-review of my own code

[x] I have commented my code, particularly in hard-to-understand areas (Added clear comments for the Issue #342 rule blocks)

[ ] I have made corresponding changes to the documentation

[x] My changes generate no new warnings

[x] I have added tests that prove my fix is effective or that my feature works (Updated the existing test suite to assert the new rules)

[x] New and existing unit tests pass locally with my changes

[ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Events now require authentication to view (no longer public).
  * Participant visibility tightened—removed broader access paths so only admins, event owners, or self-by-id can read.
  * Attendance, certificates, and analytics access restricted to admins, event owners, or matching authenticated users where applicable.
* **Tests**
  * Updated tests to expect denied reads for unauthenticated/unauthorized users and added regression coverage for event subcollections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->