### PR TITLE
ui-ux: standardize metric badge pluralization for views (#308)

### DIFF
--- a/app/src/components/EventCard.js
+++ b/app/src/components/EventCard.js
@@ -40,6 +40,20 @@ import PropTypes from 'prop-types';
 const profileCache = new Map();
 const profileRequestCache = new Map();
 
+/**
+ * formatMetric — adaptive pluralization helper for metric badges (Issue #308)
+ * Returns a grammatically correct string for any numeric metric.
+ *
+ * @param {number|undefined|null} value  - Raw numeric value from the database
+ * @param {string} singular              - Singular label, e.g. "View"
+ * @param {string} plural                - Plural label,   e.g. "Views"
+ * @returns {string}                     - e.g. "1 View", "0 Views", "42 Views"
+ */
+const formatMetric = (value, singular, plural) => {
+    const count = value ?? 0;
+    return `${count} ${count === 1 ? singular : plural}`;
+};
+
 const EventCard = memo(
     ({
         event,
@@ -304,6 +318,8 @@ const EventCard = memo(
                                     {event.eventMode === 'online' ? 'Online' : event.location}
                                 </Text>
                             </View>
+
+                            {/* ✅ Issue #308 — views metric now uses formatMetric for correct pluralization */}
                             <View style={styles.infoItem}>
                                 <Ionicons
                                     name="eye-outline"
@@ -313,7 +329,7 @@ const EventCard = memo(
                                 <Text
                                     style={[styles.infoText, { color: theme.colors.textSecondary }]}
                                 >
-                                    {event.views || 0} Views
+                                    {formatMetric(event.views, 'View', 'Views')}
                                 </Text>
                             </View>
 
@@ -357,7 +373,7 @@ const EventCard = memo(
                                         borderColor: '#EAB308',
                                     }}
                                 >
-                                    <Text style={{ fontSize: 10, lineHeight: 14 }}>ðŸ¦</Text>
+                                    <Text style={{ fontSize: 10, lineHeight: 14 }}>🐦</Text>
                                     <Text
                                         style={{
                                             fontSize: 10,
@@ -377,7 +393,7 @@ const EventCard = memo(
                             style={[styles.priceBadge, { backgroundColor: theme.colors.secondary }]}
                         >
                             <Text style={styles.priceText}>
-                                {event.isPaid ? `\u20B9${currentPrice}` : 'FREE'}
+                                {event.isPaid ? `₹${currentPrice}` : 'FREE'}
                             </Text>
                         </View>
                     </View>


### PR DESCRIPTION
## Summary
Fixes #308

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Metric badges were rendering raw database values without pluralization checks, 
causing grammatical issues like "1 Views" in the UI.

Added a `formatMetric(value, singular, plural)` helper that:
- Returns singular label when value === 1 (e.g. "1 View")
- Returns plural label for all other values (e.g. "0 Views", "42 Views")
- Falls back to `0` when value is `undefined` or `null`

Applied to the views metric badge in `EventCard.js`.

## How Has This Been Tested?
- [x] Manually verified rendering for values: 0, 1, and 42
- [x] Verified undefined/null values render as "0 Views"

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event card view metric badges now display with grammatically correct singular/plural formatting based on actual counts.
  * Price badge currency symbol rendering has been improved for enhanced clarity and consistency.
  * Early-bird indicator styling has been refined and updated for better visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->