### PR TITLE
Fix: Replace markdown bold with HTML strong tag inside div element

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,8 @@ If you run into issues or have questions:
 ---
  
 <div align="center">
-**Empowering campus communities, one event at a time.**
+<!-- Fix: Changed markdown bold to HTML strong tag since markdown doesn't render inside HTML div tags -->
+<strong>Empowering campus communities, one event at a time.</strong>
  
 <a href="#">⬆ Back to Top</a>
  


### PR DESCRIPTION
# Description
Fixed broken markdown bold text inside an HTML div tag in README.md.

The footer section had **Empowering campus communities, one event at a time.**
using markdown bold syntax inside a <div align="center"> HTML tag.
Markdown formatting does not render inside HTML tags, so the text
was displaying with literal asterisks instead of bold formatting.

Fixed by replacing the markdown bold syntax with HTML <strong> tag
which renders correctly inside HTML div elements.

Fixes #

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
1. Open README.md on GitHub
2. Navigate to the footer section
3. Verify "Empowering campus communities, one event at a time."
   now renders as bold text without asterisks

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed tagline text rendering in README to display correctly across all viewing contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->