### PR TITLE
fix: replace array index keys with stable identifiers in mapped lists

### DIFF
--- a/app/src/components/CustomTabBar.js
+++ b/app/src/components/CustomTabBar.js
@@ -50,7 +50,7 @@ export default function CustomTabBar({ state, descriptors, navigation }) {
 
                         return (
                             <TouchableOpacity
-                                key={index}
+                                key={route.key}
                                 accessible={true}
                                 accessibilityRole="button"
                                 accessibilityState={isFocused ? { selected: true } : {}}

--- a/app/src/components/FeaturedCarousel.js
+++ b/app/src/components/FeaturedCarousel.js
@@ -34,7 +34,7 @@ export default function FeaturedCarousel({ data = [], onEventPress, isLoading = 
             >
                 {data.map((item, index) => (
                     <TouchableOpacity
-                        key={item.id || index}
+                        key={item.id}
                         style={styles.card}
                         onPress={() => onEventPress && onEventPress(item)}
                         activeOpacity={0.9}

--- a/app/src/screens/EventChatScreen.js
+++ b/app/src/screens/EventChatScreen.js
@@ -362,8 +362,8 @@ export default function EventChatScreen({ route, navigation }) {
                             showsHorizontalScrollIndicator={false}
                             contentContainerStyle={{ padding: 10, gap: 15 }}
                         >
-                            {emojis.map((emoji, index) => (
-                                <TouchableOpacity key={index} onPress={() => onEmojiSelect(emoji)}>
+                            {emojis.map((emoji) => (
+                                <TouchableOpacity key={emoji} onPress={() => onEmojiSelect(emoji)}>
                                     <Text style={{ fontSize: 24 }}>{emoji}</Text>
                                 </TouchableOpacity>
                             ))}


### PR DESCRIPTION
## Description

Three mapped lists across the codebase were using array index as the React key prop, which can cause React to mismanage component identity during re-renders — leading to lost focus, stale state, and incorrect animations.

## Issue Cause

Each component passed the second `.map()` parameter (index) to the `key` prop instead of a stable unique identifier from the data itself.

## What We Did

- **EventChatScreen.js**: Changed `key={index}` to `key={emoji}` in the emoji picker. Each emoji character is unique and stable in the list.
- **CustomTabBar.js**: Changed `key={index}` to `key={route.key}`. React Navigation provides a unique `route.key` for every tab route.
- **FeaturedCarousel.js**: Changed `key={item.id || index}` to `key={item.id}`. Carousel events always have an `id` field, so the index fallback is unnecessary.

## Additional Context

- Emoji list is static and all characters are unique, making the emoji itself an ideal stable key.
- `route.key` is guaranteed by React Navigation to be unique across tab navigators.
- Event data from the backend always includes an `id` field.

## Checklist

- [x] Code follows existing conventions
- [x] No regressions in component behavior
- [x] Better React reconciliation performance
Fixes #398 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal list reconciliation stability across tab navigation, carousel items, and emoji picker components for more reliable UI rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->