### PR TITLE
fix(registration): route event card registration through detail

### DIFF
--- a/app/src/components/EventCard.js
+++ b/app/src/components/EventCard.js
@@ -12,17 +12,7 @@ import {
     getDocs,
 } from 'firebase/firestore';
 import React, { useEffect, useRef, useState, memo } from 'react';
-import {
-    Image,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View,
-    Switch,
-    Platform,
-    ActivityIndicator,
-    Alert,
-} from 'react-native';
+import { Image, StyleSheet, Text, TouchableOpacity, View, Switch, Platform } from 'react-native';
 import { db } from '../lib/firebaseConfig';
 import { theme as globalTheme } from '../lib/theme';
 import { useTheme } from '../lib/ThemeContext';
@@ -31,7 +21,6 @@ import { ShimmerItem } from './SkeletonLoader';
 import { useAuth } from '../lib/AuthContext';
 import { triggerBuddyMatchNotification } from '../lib/notificationService';
 import { formatEventDate, formatEventTime } from '../lib/formatEventDate';
-import { safeToggleEventAction } from '../lib/participantService';
 import PropTypes from 'prop-types';
 
 // Module-level profile cache registry
@@ -72,11 +61,9 @@ const EventCard = memo(
         const [bannerLoaded, setBannerLoaded] = useState(false);
         const [flyerLoaded, setFlyerLoaded] = useState(false);
         const [lookingForBuddy, setLookingForBuddy] = useState(false);
-
-        // UI Loading State
-        const [isProcessing, setIsProcessing] = useState(false);
-        // Synchronous lock reference to block multi-taps inside the same render frame
-        const isProcessingRef = useRef(false);
+        const [isNavigatingToDetail, setIsNavigatingToDetail] = useState(false);
+        const navigationLockRef = useRef(false);
+        const navigationUnlockTimerRef = useRef(null);
 
         useEffect(() => {
             if (!isRegistered || !user || !event?.id) return;
@@ -163,26 +150,29 @@ const EventCard = memo(
             };
         }, [event?.ownerId, event?.organization]);
 
-        // Gated same-frame input execution track blocker handler
-        const handleRegisterPress = async () => {
-            if (isProcessingRef.current || !user || !event?.id) return;
+        useEffect(
+            () => () => {
+                if (navigationUnlockTimerRef.current) {
+                    clearTimeout(navigationUnlockTimerRef.current);
+                }
+            },
+            [],
+        );
 
-            isProcessingRef.current = true;
-            setIsProcessing(true);
+        const navigateToDetail = () => {
+            if (!event?.id || navigationLockRef.current) return;
 
-            try {
-                await safeToggleEventAction(db, user.uid, event.id, true);
-                navigation.navigate('EventDetail', { eventId: event.id });
-            } catch (error) {
-                console.error('Spam button trigger rejected processing error:', error);
-                Alert.alert(
-                    'Registration Failed',
-                    'Unable to register for this event. Please verify your internet connection and try again.',
-                );
-            } finally {
-                isProcessingRef.current = false;
-                setIsProcessing(false);
-            }
+            navigationLockRef.current = true;
+            setIsNavigatingToDetail(true);
+            navigation.navigate('EventDetail', { eventId: event.id });
+            navigationUnlockTimerRef.current = setTimeout(() => {
+                navigationLockRef.current = false;
+                setIsNavigatingToDetail(false);
+            }, 1000);
+        };
+
+        const handleRegisterPress = () => {
+            navigateToDetail();
         };
 
         if (!event) return null;
@@ -325,20 +315,18 @@ const EventCard = memo(
                     style={[
                         styles.registerBtn,
                         {
-                            backgroundColor: isProcessing
+                            backgroundColor: isNavigatingToDetail
                                 ? theme.colors.border
                                 : theme.colors.primary,
                             ...theme.shadows.default,
                         },
                     ]}
-                    disabled={isProcessing}
+                    accessibilityState={{ disabled: isNavigatingToDetail }}
+                    disabled={isNavigatingToDetail}
                     onPress={handleRegisterPress}
+                    testID="event-card-register-button"
                 >
-                    {isProcessing ? (
-                        <ActivityIndicator size="small" color="#ffffff" />
-                    ) : (
-                        <Text style={styles.registerText}>REGISTER</Text>
-                    )}
+                    <Text style={styles.registerText}>REGISTER</Text>
                 </TouchableOpacity>
             );
         };
@@ -351,7 +339,7 @@ const EventCard = memo(
                     style,
                 ]}
                 activeOpacity={0.9}
-                onPress={() => navigation.navigate('EventDetail', { eventId: event.id })}
+                onPress={navigateToDetail}
             >
                 <View style={[styles.bannerContainer, isRecommended && { height: 140 }]}>
                     {!bannerLoaded && (

--- a/app/src/components/__tests__/EventCard.test.js
+++ b/app/src/components/__tests__/EventCard.test.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import EventCard from '../EventCard';
+
+const mockNavigate = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+    useNavigation: () => ({
+        navigate: mockNavigate,
+    }),
+}));
+
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const { Text } = require('react-native');
+
+    const MockIcon = ({ name }) => React.createElement(Text, null, name);
+    MockIcon.propTypes = {
+        name: PropTypes.string,
+    };
+
+    return {
+        Ionicons: MockIcon,
+    };
+});
+
+jest.mock('expo-linear-gradient', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const { View } = require('react-native');
+
+    const LinearGradient = ({ children, style }) => React.createElement(View, { style }, children);
+
+    LinearGradient.propTypes = {
+        children: PropTypes.node,
+        style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    };
+
+    return {
+        LinearGradient,
+    };
+});
+
+jest.mock('firebase/firestore', () => ({
+    collection: jest.fn(),
+    doc: jest.fn(),
+    getDoc: jest.fn(),
+    getDocs: jest.fn(),
+    onSnapshot: jest.fn(),
+    query: jest.fn(),
+    updateDoc: mockUpdateDoc,
+    where: jest.fn(),
+}));
+
+jest.mock('../../lib/firebaseConfig', () => ({
+    db: {},
+}));
+
+jest.mock('../../lib/AuthContext', () => ({
+    useAuth: () => ({
+        user: {
+            uid: 'user-1',
+            displayName: 'Test User',
+        },
+    }),
+}));
+
+jest.mock('../../lib/ThemeContext', () => ({
+    useTheme: () => ({
+        theme: {
+            colors: {
+                background: '#ffffff',
+                border: '#dddddd',
+                error: '#dc2626',
+                primary: '#2563eb',
+                secondary: '#16a34a',
+                success: '#15803d',
+                surface: '#ffffff',
+                text: '#111111',
+                textSecondary: '#555555',
+            },
+            shadows: {
+                default: {},
+                small: {},
+            },
+        },
+    }),
+}));
+
+jest.mock('../../lib/notificationService', () => ({
+    triggerBuddyMatchNotification: jest.fn(),
+}));
+
+jest.mock('../SkeletonLoader', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const { View } = require('react-native');
+
+    const ShimmerItem = ({ style }) => React.createElement(View, { style });
+
+    ShimmerItem.propTypes = {
+        style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    };
+
+    return {
+        ShimmerItem,
+    };
+});
+
+const paidEvent = {
+    id: 'paid-event-1',
+    bannerUrl: 'https://example.com/banner.png',
+    category: 'Tech',
+    detailImageUrl: 'https://example.com/detail.png',
+    endAt: '2099-01-01T12:00:00.000Z',
+    eventMode: 'offline',
+    isPaid: true,
+    location: 'Auditorium',
+    organization: 'CS Club',
+    price: 499,
+    startAt: '2099-01-01T10:00:00.000Z',
+    title: 'Paid Workshop',
+};
+
+describe('EventCard registration', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it('routes register presses to the authoritative event detail flow', () => {
+        const { getByTestId } = render(<EventCard event={paidEvent} />);
+
+        fireEvent.press(getByTestId('event-card-register-button'));
+        fireEvent.press(getByTestId('event-card-register-button'));
+
+        expect(mockNavigate).toHaveBeenCalledWith('EventDetail', {
+            eventId: 'paid-event-1',
+        });
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+});

--- a/app/src/lib/participantService.js
+++ b/app/src/lib/participantService.js
@@ -1,11 +1,4 @@
-import {
-    collection,
-    getDocs,
-    onSnapshot,
-    doc,
-    runTransaction,
-    increment,
-} from 'firebase/firestore';
+import { collection, getDocs, onSnapshot } from 'firebase/firestore';
 
 // In-memory listener registry to dedupe reads and subscriptions per event
 const registry = new Map(); // eventId -> { subscribers: Set(fn), unsubscribe: fn|null, data: any, lastFetched: number, fetchPromise: Promise<any>|null }
@@ -136,54 +129,10 @@ export function clearParticipantCache(eventId) {
     }
 }
 
-/**
- * 🚀 GSSoC 2026 / Issue #266: Idempotent Event Registration Processing
- * Uses an atomic transaction constraint check to ensure rapid repeated button presses
- * can never write duplicate entries or double-increment attendance counters.
- */
-export const safeToggleEventAction = async (db, userId, eventId, isRegistering) => {
-    const eventRef = doc(db, 'events', eventId);
-    const participantRef = doc(db, `events/${eventId}/participants`, userId);
-
-    try {
-        await runTransaction(db, async transaction => {
-            const eventDoc = await transaction.get(eventRef);
-            if (!eventDoc.exists()) {
-                throw new Error('Target event mapping does not exist upstream.');
-            }
-
-            // 🔍 Technical Task 3: Unique structural constraint check (User ID + Event ID)
-            const participantDoc = await transaction.get(participantRef);
-            const wasRegistered =
-                participantDoc.exists() && participantDoc.data()?.registered === true;
-
-            // 🛑 IDEMPOTENCY GUARD: If the state matches what they want, exit immediately!
-            if (wasRegistered === isRegistering) {
-                console.log('Idempotent block: Request already handled, ignoring double trigger.');
-                return;
-            }
-
-            // 1. Write registration state change securely with sync timestamp tracking
-            transaction.set(
-                participantRef,
-                {
-                    id: userId,
-                    registered: isRegistering,
-                    synchronizedAt: new Date().toISOString(),
-                },
-                { merge: true },
-            );
-
-            // 2. Atomically update seat counters without overlapping drift
-            transaction.update(eventRef, {
-                totalAttendees: increment(isRegistering ? 1 : -1),
-            });
-        });
-        console.log('Database transaction completed safely.');
-    } catch (error) {
-        console.error('Idempotent pipeline processing error:', error);
-        throw error;
-    }
+export const safeToggleEventAction = async () => {
+    throw new Error(
+        'safeToggleEventAction is deprecated. Route registration through EventDetail so payment, custom form, ticket, and analytics flows stay consistent.',
+    );
 };
 
 export default {


### PR DESCRIPTION
## What
Fixes #409 by preventing event cards from directly mutating registration documents. The card-level `REGISTER` action now routes users to the event detail screen, where paid checkout, custom forms, and normal RSVP handling already live.

## How
Removed the `EventCard` dependency on `safeToggleEventAction`, deleted the obsolete direct-write helper from `participantService`, and added a component regression test that verifies card registration routes to `EventDetail` without issuing Firestore updates.

## Testing
- `npm test -- --runInBand`
- `npm test -- --runInBand --coverage=false`
- `npm test -- --runInBand src/components/__tests__/EventCard.test.js --coverage=false`
- `npx eslint src/components/EventCard.js src/lib/participantService.js src/components/__tests__/EventCard.test.js`
- `npm run lint` (passes with existing warnings in `LocationHeatmapScreen.js` and `UserFeed.js`)

## Risks / Notes
This intentionally changes the event-card `REGISTER` button from an immediate write to a route into the canonical registration flow. That avoids bypassing payment, form responses, ticket creation, user participation indexes, points, and analytics counters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the event registration flow; the REGISTER button now navigates to the event details page instead of immediately processing registration.

* **Tests**
  * Added test coverage to verify the REGISTER button navigation behavior works correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->