### PR TITLE
Implement audit logging for sensitive Firestore operations

### DIFF
--- a/cloud-functions/src/auditLog.ts
+++ b/cloud-functions/src/auditLog.ts
@@ -1,0 +1,76 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+
+/**
+ * Determines the action type from before/after existence.
+ */
+function getAction(
+    beforeExists: boolean, afterExists: boolean,
+): 'create' | 'update' | 'delete' {
+  if (!beforeExists && afterExists) return 'create';
+  if (beforeExists && !afterExists) return 'delete';
+  return 'update';
+}
+
+/**
+ * Extracts the userId based on action type and document data.
+ */
+function getUserId(
+    action: 'create' | 'update' | 'delete',
+    beforeData: admin.firestore.DocumentData | undefined,
+    afterData: admin.firestore.DocumentData | undefined,
+): string | null {
+  if (action === 'create' && afterData) {
+    return afterData.createdBy || afterData.updatedBy || null;
+  }
+  if (action === 'update' && afterData) {
+    return afterData.updatedBy || afterData.createdBy || null;
+  }
+  if (action === 'delete' && beforeData) {
+    return beforeData.updatedBy || beforeData.createdBy || null;
+  }
+  return null;
+}
+
+/**
+ * Firestore trigger that logs all create, update, and delete operations
+ * across collections into the `auditLog` admin-only collection.
+ *
+ * It prevents self-triggering by explicitly checking that the collection
+ * is not 'auditLog'.
+ */
+export const auditLog = functions.firestore
+    .document('{collectionId}/{docId}')
+    .onWrite(async (change, context) => {
+      const collection = context.params.collectionId;
+
+      // Prevent self-triggering recursion
+      if (collection === 'auditLog') {
+        return;
+      }
+
+      const beforeExists = change.before?.exists ?? false;
+      const afterExists = change.after?.exists ?? false;
+
+      const beforeData = beforeExists ? change.before.data() : undefined;
+      const afterData = afterExists ? change.after.data() : undefined;
+
+      const action = getAction(beforeExists, afterExists);
+      const userId = getUserId(action, beforeData, afterData);
+
+      const logEntry = {
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+        userId,
+        action,
+        collection,
+        documentId: context.params.docId,
+        before: beforeData || null,
+        after: afterData || null,
+      };
+
+      try {
+        await admin.firestore().collection('auditLog').add(logEntry);
+      } catch (error) {
+        console.error('Failed to write audit log entry:', error);
+      }
+    });

--- a/cloud-functions/src/index.ts
+++ b/cloud-functions/src/index.ts
@@ -16,3 +16,4 @@ export * from './computeShowUpRatios';
 export * from './branchReport';
 export * from './postEventFeedback';
 export * from './sendBulkEmails';
+export * from './auditLog';

--- a/firestore.rules
+++ b/firestore.rules
@@ -268,6 +268,11 @@ service cloud.firestore {
       allow read, update, delete: if request.auth != null && ('userId' in resource.data) && request.auth.uid == resource.data.userId;
     }
     
+    // Audit Log Collection (admin only)
+    match /auditLog/{logId} {
+      allow read: if isAdmin();
+    }
+
     // Global Administration Controls
     match /admin/{doc} {
       allow read, write: if isAdmin();


### PR DESCRIPTION
Closes #343. Implements Firestore trigger that logs all document writes to an admin-only 'auditLog' collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic audit logging that captures all document modifications across collections, including creation, updates, and deletion events with complete change tracking
  * Audit logs include before/after data snapshots and user attribution to identify who made each change
  * Access to audit logs restricted to administrator accounts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->