### PR TITLE
feat: implement soft deletes for events (fixes #332)

### DIFF
--- a/app/src/screens/DesktopAdmin.js
+++ b/app/src/screens/DesktopAdmin.js
@@ -1,4 +1,4 @@
-import { collection, doc, getDocs, updateDoc } from 'firebase/firestore';
+import { collection, doc, getDocs, updateDoc, deleteField } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { useEffect, useState } from 'react';
 import {
@@ -45,6 +45,7 @@ const downloadBase64Pdf = ({ base64, fileName }) => {
 
 export default function DesktopAdmin() {
     const [activeTab, setActiveTab] = useState('clubs'); // 'clubs' | 'events' | 'analytics'
+    const [activeSubTab, setActiveSubTab] = useState('active'); // 'active' | 'deleted'
     const [clubs, setClubs] = useState([]);
     const [events, setEvents] = useState([]);
     const [reportLoading, setReportLoading] = useState(false);
@@ -107,6 +108,20 @@ export default function DesktopAdmin() {
             );
         } finally {
             setReportLoading(false);
+        }
+    };
+
+    const handleRestoreEvent = async eventId => {
+        try {
+            await updateDoc(doc(db, 'events', eventId), {
+                deletedAt: deleteField(),
+                deletedBy: deleteField(),
+            });
+            fetchEvents();
+            Alert.alert('Restored', 'Event restored successfully.');
+        } catch (error) {
+            console.error(error);
+            Alert.alert('Error', 'Failed to restore event');
         }
     };
 
@@ -230,21 +245,50 @@ export default function DesktopAdmin() {
                     )}
 
                     {activeTab === 'events' && (
-                        <View style={styles.table}>
-                            <View style={[styles.row, styles.headerRow]}>
-                                <Text style={styles.cell}>Title</Text>
-                                <Text style={styles.cell}>Date</Text>
-                                <Text style={styles.cell}>Category</Text>
+                        <View>
+                            <View style={styles.tabRow}>
+                                <TouchableOpacity
+                                    style={[styles.subTab, activeSubTab === 'active' && styles.activeSubTab]}
+                                    onPress={() => setActiveSubTab('active')}
+                                >
+                                    <Text style={[styles.subTabText, activeSubTab === 'active' && styles.activeSubTabText]}>Active</Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                    style={[styles.subTab, activeSubTab === 'deleted' && styles.activeSubTab]}
+                                    onPress={() => setActiveSubTab('deleted')}
+                                >
+                                    <Text style={[styles.subTabText, activeSubTab === 'deleted' && styles.activeSubTabText]}>Deleted</Text>
+                                </TouchableOpacity>
                             </View>
-                            {events.map(event => (
-                                <View key={event.id} style={styles.row}>
-                                    <Text style={styles.cell}>{event.title}</Text>
-                                    <Text style={styles.cell}>
-                                        {formatEventDate(event.startAt)}
-                                    </Text>
-                                    <Text style={styles.cell}>{event.category}</Text>
+                            <View style={styles.table}>
+                                <View style={[styles.row, styles.headerRow]}>
+                                    <Text style={styles.cell}>Title</Text>
+                                    <Text style={styles.cell}>Date</Text>
+                                    <Text style={styles.cell}>Category</Text>
+                                    <Text style={styles.cell}>Action</Text>
                                 </View>
-                            ))}
+                                {events
+                                    .filter(e => activeSubTab === 'deleted' ? e.deletedAt != null : !e.deletedAt)
+                                    .map(event => (
+                                    <View key={event.id} style={styles.row}>
+                                        <Text style={styles.cell}>{event.title}</Text>
+                                        <Text style={styles.cell}>
+                                            {formatEventDate(event.startAt)}
+                                        </Text>
+                                        <Text style={styles.cell}>{event.category}</Text>
+                                        <View style={styles.cell}>
+                                            {activeSubTab === 'deleted' && (
+                                                <TouchableOpacity
+                                                    style={styles.restoreBtn}
+                                                    onPress={() => handleRestoreEvent(event.id)}
+                                                >
+                                                    <Text style={styles.restoreBtnText}>Restore</Text>
+                                                </TouchableOpacity>
+                                            )}
+                                        </View>
+                                    </View>
+                                ))}
+                            </View>
                         </View>
                     )}
 
@@ -438,5 +482,38 @@ const styles = StyleSheet.create({
         color: '#fff',
         fontWeight: 'bold',
         fontSize: 14,
+    },
+    tabRow: {
+        flexDirection: 'row',
+        gap: 8,
+        marginBottom: 16,
+    },
+    subTab: {
+        paddingHorizontal: 20,
+        paddingVertical: 8,
+        borderRadius: 6,
+        backgroundColor: '#eee',
+    },
+    activeSubTab: {
+        backgroundColor: '#2563eb',
+    },
+    subTabText: {
+        fontSize: 14,
+        color: '#555',
+        fontWeight: '600',
+    },
+    activeSubTabText: {
+        color: '#fff',
+    },
+    restoreBtn: {
+        backgroundColor: '#4CAF50',
+        padding: 5,
+        borderRadius: 4,
+        alignItems: 'center',
+        width: 80,
+    },
+    restoreBtnText: {
+        color: '#fff',
+        fontSize: 12,
     },
 });

--- a/app/src/screens/MobileAdmin.js
+++ b/app/src/screens/MobileAdmin.js
@@ -41,8 +41,20 @@ export default function MobileAdmin() {
                 const now = new Date();
                 snapshot.forEach(doc => {
                     const data = doc.data();
+                    if (data.deletedAt != null) return;
                     // Filter future/ongoing events (endAt >= now, or startAt >= now if no endAt)
                     if (new Date(data.endAt || data.startAt) >= now) {
+                        list.push({ id: doc.id, ...data });
+                    }
+                });
+                setEvents(list);
+            } else if (activeTab === 'deleted') {
+                const q = query(collection(db, 'events'), where('status', '==', 'active'));
+                const snapshot = await getDocs(q);
+                const list = [];
+                snapshot.forEach(doc => {
+                    const data = doc.data();
+                    if (data.deletedAt != null) {
                         list.push({ id: doc.id, ...data });
                     }
                 });
@@ -113,6 +125,20 @@ export default function MobileAdmin() {
         }
     };
 
+    const handleRestoreEvent = async eventId => {
+        try {
+            await updateDoc(doc(db, 'events', eventId), {
+                deletedAt: null,
+                deletedBy: null,
+            });
+            Alert.alert('Restored', 'Event restored successfully.');
+            fetchData();
+        } catch (_e) {
+            console.error('Restore failed:', _e);
+            Alert.alert('Error', 'Failed to restore event');
+        }
+    };
+
     const handleRejectAppeal = async eventId => {
         try {
             await updateDoc(doc(db, 'events', eventId), {
@@ -156,6 +182,8 @@ export default function MobileAdmin() {
         let emptyMessage;
         if (activeTab === 'events') {
             emptyMessage = 'No active events found';
+        } else if (activeTab === 'deleted') {
+            emptyMessage = 'No deleted events';
         } else if (activeTab === 'requests') {
             emptyMessage = 'No pending club requests';
         } else {
@@ -229,6 +257,31 @@ export default function MobileAdmin() {
         </View>
     );
 
+    const renderDeletedItem = ({ item }) => (
+        <View style={styles.card}>
+            <View style={styles.cardHeader}>
+                <View style={[styles.iconContainer, { backgroundColor: '#FF444420' }]}>
+                    <Ionicons name="trash" size={24} color="#FF4444" />
+                </View>
+                <View style={{ flex: 1 }}>
+                    <Text style={styles.cardTitle}>{item.title}</Text>
+                    <Text style={[styles.cardSubtitle, { color: '#FF4444' }]}>DELETED</Text>
+                </View>
+            </View>
+            <Text style={styles.cardDesc}>
+                {formatEventDate(item.startAt)} at {item.location}
+            </Text>
+            <View style={styles.actionRow}>
+                <TouchableOpacity
+                    style={[styles.actionBtn, styles.approveBtn]}
+                    onPress={() => handleRestoreEvent(item.id)}
+                >
+                    <Text style={[styles.actionBtnText, { color: '#4CAF50' }]}>Restore</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+
     const renderAppealItem = ({ item }) => (
         <View style={styles.card}>
             <View style={styles.cardHeader}>
@@ -269,6 +322,9 @@ export default function MobileAdmin() {
     if (activeTab === 'events') {
         listData = events;
         listRenderItem = renderEventItem;
+    } else if (activeTab === 'deleted') {
+        listData = events;
+        listRenderItem = renderDeletedItem;
     } else if (activeTab === 'requests') {
         listData = requests;
         listRenderItem = renderRequestItem;
@@ -303,21 +359,23 @@ export default function MobileAdmin() {
                     </Text>
                 </TouchableOpacity>
                 <TouchableOpacity
-                    style={[styles.tab, activeTab === 'requests' && styles.activeTab]}
-                    onPress={() => setActiveTab('requests')}
-                >
-                    <Text
-                        style={[styles.tabText, activeTab === 'requests' && styles.activeTabText]}
-                    >
-                        Club Requests
-                    </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
                     style={[styles.tab, activeTab === 'appeals' && styles.activeTab]}
                     onPress={() => setActiveTab('appeals')}
                 >
-                    <Text style={[styles.tabText, activeTab === 'appeals' && styles.activeTabText]}>
+                    <Text
+                        style={[styles.tabText, activeTab === 'appeals' && styles.activeTabText]}
+                    >
                         Appeals
+                    </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                    style={[styles.tab, activeTab === 'deleted' && styles.activeTab]}
+                    onPress={() => setActiveTab('deleted')}
+                >
+                    <Text
+                        style={[styles.tabText, activeTab === 'deleted' && styles.activeTabText]}
+                    >
+                        Deleted
                     </Text>
                 </TouchableOpacity>
             </View>

--- a/app/src/screens/MobileAdmin.js
+++ b/app/src/screens/MobileAdmin.js
@@ -49,15 +49,10 @@ export default function MobileAdmin() {
                 });
                 setEvents(list);
             } else if (activeTab === 'deleted') {
-                const q = query(collection(db, 'events'), where('status', '==', 'active'));
+                const q = query(collection(db, 'events'), where('status', '==', 'deleted'));
                 const snapshot = await getDocs(q);
                 const list = [];
-                snapshot.forEach(doc => {
-                    const data = doc.data();
-                    if (data.deletedAt != null) {
-                        list.push({ id: doc.id, ...data });
-                    }
-                });
+                snapshot.forEach(doc => list.push({ id: doc.id, ...doc.data() }));
                 setEvents(list);
             } else if (activeTab === 'requests') {
                 const q = query(collection(db, 'clubs'), where('approvalStatus', '==', 'pending'));
@@ -130,6 +125,7 @@ export default function MobileAdmin() {
             await updateDoc(doc(db, 'events', eventId), {
                 deletedAt: deleteField(),
                 deletedBy: deleteField(),
+                status: 'active',
             });
             Alert.alert('Restored', 'Event restored successfully.');
             fetchData();
@@ -271,6 +267,14 @@ export default function MobileAdmin() {
             <Text style={styles.cardDesc}>
                 {formatEventDate(item.startAt)} at {item.location}
             </Text>
+            {item.deletedAt && (
+                <Text style={[styles.cardDesc, { color: '#888', fontSize: 12, marginTop: 4 }]}>
+                    Permanently deleted after{' '}
+                    {new Date(
+                        item.deletedAt.toDate().getTime() + 30 * 24 * 60 * 60 * 1000
+                    ).toLocaleDateString()}
+                </Text>
+            )}
             <View style={styles.actionRow}>
                 <TouchableOpacity
                     style={[styles.actionBtn, styles.approveBtn]}
@@ -356,6 +360,16 @@ export default function MobileAdmin() {
                 >
                     <Text style={[styles.tabText, activeTab === 'events' && styles.activeTabText]}>
                         Events
+                    </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                    style={[styles.tab, activeTab === 'requests' && styles.activeTab]}
+                    onPress={() => setActiveTab('requests')}
+                >
+                    <Text
+                        style={[styles.tabText, activeTab === 'requests' && styles.activeTabText]}
+                    >
+                        Club Requests
                     </Text>
                 </TouchableOpacity>
                 <TouchableOpacity

--- a/app/src/screens/MobileAdmin.js
+++ b/app/src/screens/MobileAdmin.js
@@ -128,8 +128,8 @@ export default function MobileAdmin() {
     const handleRestoreEvent = async eventId => {
         try {
             await updateDoc(doc(db, 'events', eventId), {
-                deletedAt: null,
-                deletedBy: null,
+                deletedAt: deleteField(),
+                deletedBy: deleteField(),
             });
             Alert.alert('Restored', 'Event restored successfully.');
             fetchData();

--- a/app/src/screens/MyEventsScreen.js
+++ b/app/src/screens/MyEventsScreen.js
@@ -44,7 +44,9 @@ export default function MyEventsScreen({ navigation }) {
             snapshot => {
                 const list = [];
                 snapshot.forEach(doc => {
-                    list.push({ id: doc.id, ...doc.data() });
+                    const data = doc.data();
+                    if (data.deletedAt != null) return;
+                    list.push({ id: doc.id, ...data });
                 });
                 // Sort client-side by date
                 list.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
@@ -65,6 +67,7 @@ export default function MyEventsScreen({ navigation }) {
     const handleDelete = async eventId => {
         const confirmMsg = 'Are you sure? The event will be soft-deleted and can be restored by an admin within 30 days.';
         if (Platform.OS === 'web') {
+            if (!window.confirm(confirmMsg)) return;
             try {
                 await updateDoc(doc(db, 'events', eventId), {
                     deletedAt: serverTimestamp(),

--- a/app/src/screens/MyEventsScreen.js
+++ b/app/src/screens/MyEventsScreen.js
@@ -65,13 +65,14 @@ export default function MyEventsScreen({ navigation }) {
     }, [user, refreshNonce, isFocused]);
 
     const handleDelete = async eventId => {
-        const confirmMsg = 'Are you sure? The event will be soft-deleted and can be restored by an admin within 30 days.';
+        const confirmMsg = 'Are you sure? The event will be soft-deleted and can be restored by an admin within 30 days. Attendees can no longer register.';
         if (Platform.OS === 'web') {
             if (!globalThis.confirm(confirmMsg)) return;
             try {
                 await updateDoc(doc(db, 'events', eventId), {
                     deletedAt: serverTimestamp(),
                     deletedBy: user.uid,
+                    status: 'deleted',
                 });
             } catch (_e) {
                 console.error('Delete event failed (Web):', _e);
@@ -88,6 +89,7 @@ export default function MyEventsScreen({ navigation }) {
                             await updateDoc(doc(db, 'events', eventId), {
                                 deletedAt: serverTimestamp(),
                                 deletedBy: user.uid,
+                                status: 'deleted',
                             });
                         } catch (_e) {
                             console.error('Delete event failed (Native):', _e);

--- a/app/src/screens/MyEventsScreen.js
+++ b/app/src/screens/MyEventsScreen.js
@@ -67,7 +67,7 @@ export default function MyEventsScreen({ navigation }) {
     const handleDelete = async eventId => {
         const confirmMsg = 'Are you sure? The event will be soft-deleted and can be restored by an admin within 30 days.';
         if (Platform.OS === 'web') {
-            if (!window.confirm(confirmMsg)) return;
+            if (!globalThis.confirm(confirmMsg)) return;
             try {
                 await updateDoc(doc(db, 'events', eventId), {
                     deletedAt: serverTimestamp(),

--- a/app/src/screens/MyEventsScreen.js
+++ b/app/src/screens/MyEventsScreen.js
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { FlashList } from '@shopify/flash-list';
-import { collection, deleteDoc, doc, onSnapshot, query, where } from 'firebase/firestore';
+import { collection, doc, onSnapshot, query, updateDoc, where, serverTimestamp } from 'firebase/firestore';
 import React, { useEffect, useState, useCallback } from 'react';
 import {
     ActivityIndicator,
@@ -63,22 +63,29 @@ export default function MyEventsScreen({ navigation }) {
     }, [user, refreshNonce, isFocused]);
 
     const handleDelete = async eventId => {
+        const confirmMsg = 'Are you sure? The event will be soft-deleted and can be restored by an admin within 30 days.';
         if (Platform.OS === 'web') {
             try {
-                await deleteDoc(doc(db, 'events', eventId));
+                await updateDoc(doc(db, 'events', eventId), {
+                    deletedAt: serverTimestamp(),
+                    deletedBy: user.uid,
+                });
             } catch (_e) {
                 console.error('Delete event failed (Web):', _e);
                 alert('Error: Could not delete event');
             }
         } else {
-            Alert.alert('Delete Event', 'Are you sure? This cannot be undone.', [
+            Alert.alert('Delete Event', confirmMsg, [
                 { text: 'Cancel', style: 'cancel' },
                 {
                     text: 'Delete',
                     style: 'destructive',
                     onPress: async () => {
                         try {
-                            await deleteDoc(doc(db, 'events', eventId));
+                            await updateDoc(doc(db, 'events', eventId), {
+                                deletedAt: serverTimestamp(),
+                                deletedBy: user.uid,
+                            });
                         } catch (_e) {
                             console.error('Delete event failed (Native):', _e);
                             Alert.alert('Error', 'Could not delete event');

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -305,6 +305,7 @@ export default function UserFeed() {
                 snapshot.forEach(doc => {
                     const data = doc.data();
                     if (data.status === 'suspended') return;
+                    if (data.deletedAt != null) return;
                     list.push({ id: doc.id, ...data });
                 });
                 setEvents(list);
@@ -456,6 +457,7 @@ export default function UserFeed() {
             snapshot.forEach(doc => {
                 const data = doc.data();
                 if (data.status === 'suspended') return;
+                if (data.deletedAt != null) return;
                 list.push({ id: doc.id, ...data });
             });
             setEvents(list);

--- a/cloud-functions/src/index.ts
+++ b/cloud-functions/src/index.ts
@@ -17,3 +17,4 @@ export * from './branchReport';
 export * from './postEventFeedback';
 export * from './sendBulkEmails';
 export * from './auditLog';
+export * from './permanentCleanup';

--- a/cloud-functions/src/permanentCleanup.ts
+++ b/cloud-functions/src/permanentCleanup.ts
@@ -1,0 +1,37 @@
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+
+export const permanentCleanup = functions.pubsub
+  .schedule("every 24 hours")
+  .timeZone("UTC")
+  .onRun(async () => {
+    const db = admin.firestore();
+    const ninetyDaysAgo = new Date();
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+
+    const eventsSnapshot = await db
+      .collection("events")
+      .where("deletedAt", "<", ninetyDaysAgo)
+      .get();
+
+    let batch = db.batch();
+    let operationCount = 0;
+
+    for (const eventDoc of eventsSnapshot.docs) {
+      batch.delete(eventDoc.ref);
+      operationCount++;
+
+      if (operationCount === 500) {
+        await batch.commit();
+        batch = db.batch();
+        operationCount = 0;
+      }
+    }
+
+    if (operationCount > 0) {
+      await batch.commit();
+    }
+
+    console.log(`Permanent cleanup completed. Removed ${eventsSnapshot.size} events.`);
+    return null;
+  });

--- a/cloud-functions/src/permanentCleanup.ts
+++ b/cloud-functions/src/permanentCleanup.ts
@@ -9,29 +9,47 @@ export const permanentCleanup = functions.pubsub
     const ninetyDaysAgo = new Date();
     ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
 
-    const eventsSnapshot = await db
-      .collection("events")
-      .where("deletedAt", "<", ninetyDaysAgo)
-      .get();
+    let totalDeleted = 0;
 
-    let batch = db.batch();
-    let operationCount = 0;
+    try {
+      let lastDoc: admin.firestore.DocumentSnapshot | null = null;
+      let hasMore = true;
 
-    for (const eventDoc of eventsSnapshot.docs) {
-      batch.delete(eventDoc.ref);
-      operationCount++;
+      while (hasMore) {
+        let query: admin.firestore.Query = db
+          .collection("events")
+          .where("deletedAt", "<", ninetyDaysAgo)
+          .orderBy("__name__")
+          .limit(500);
 
-      if (operationCount === 500) {
-        await batch.commit();
-        batch = db.batch();
-        operationCount = 0;
+        if (lastDoc) {
+          query = query.startAfter(lastDoc);
+        }
+
+        const eventsSnapshot = await query.get();
+        hasMore = eventsSnapshot.docs.length === 500;
+        let batch = db.batch();
+        let operationCount = 0;
+
+        for (const eventDoc of eventsSnapshot.docs) {
+          batch.delete(eventDoc.ref);
+          operationCount++;
+        }
+
+        if (operationCount > 0) {
+          await batch.commit();
+          totalDeleted += operationCount;
+        }
+
+        if (hasMore) {
+          lastDoc = eventsSnapshot.docs[eventsSnapshot.docs.length - 1];
+        }
       }
+    } catch (error) {
+      console.error(`Permanent cleanup failed after deleting ${totalDeleted} events:`, error);
+      return null;
     }
 
-    if (operationCount > 0) {
-      await batch.commit();
-    }
-
-    console.log(`Permanent cleanup completed. Removed ${eventsSnapshot.size} events.`);
+    console.log(`Permanent cleanup completed. Removed ${totalDeleted} events.`);
     return null;
   });

--- a/cloud-functions/src/permanentCleanup.ts
+++ b/cloud-functions/src/permanentCleanup.ts
@@ -47,9 +47,8 @@ export const permanentCleanup = functions.pubsub
       }
     } catch (error) {
       console.error(`Permanent cleanup failed after deleting ${totalDeleted} events:`, error);
-      return null;
+      throw error;
     }
 
     console.log(`Permanent cleanup completed. Removed ${totalDeleted} events.`);
-    return null;
   });

--- a/cloud-functions/src/permanentCleanup.ts
+++ b/cloud-functions/src/permanentCleanup.ts
@@ -1,13 +1,16 @@
 import * as admin from "firebase-admin";
 import * as functions from "firebase-functions";
 
+const CLEANUP_DAYS = 30;
+
 export const permanentCleanup = functions.pubsub
   .schedule("every 24 hours")
   .timeZone("UTC")
   .onRun(async () => {
     const db = admin.firestore();
-    const ninetyDaysAgo = new Date();
-    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+    const cutoff = admin.firestore.Timestamp.fromMillis(
+      Date.now() - CLEANUP_DAYS * 24 * 60 * 60 * 1000
+    );
 
     let totalDeleted = 0;
 
@@ -18,7 +21,7 @@ export const permanentCleanup = functions.pubsub
       while (hasMore) {
         let query: admin.firestore.Query = db
           .collection("events")
-          .where("deletedAt", "<", ninetyDaysAgo)
+          .where("deletedAt", "<", cutoff)
           .orderBy("__name__")
           .limit(500);
 
@@ -32,6 +35,11 @@ export const permanentCleanup = functions.pubsub
         let operationCount = 0;
 
         for (const eventDoc of eventsSnapshot.docs) {
+          const eventData = eventDoc.data();
+          if (eventData?.ownerId) {
+            const ownerRef = db.collection("users").doc(eventData.ownerId);
+            batch.update(ownerRef, { eventCount: admin.firestore.FieldValue.increment(-1) });
+          }
           batch.delete(eventDoc.ref);
           operationCount++;
         }

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,15 @@ service cloud.firestore {
       return isValidEventTitle(data) && isValidEventCapacity(data) && isValidEventDate(data);
     }
 
+    function validateSoftDelete(before, after) {
+      let affected = after.diff(before).affectedKeys();
+      return !affected.hasAny(['deletedAt', 'deletedBy']) || (
+        !('deletedAt' in before) &&
+        'deletedAt' in after &&
+        'deletedBy' in after
+      );
+    }
+
     function validateAttendanceStatus(data) {
       return !('status' in data) || (data.status in ['rsvp', 'checked_in', 'cancelled']);
     }
@@ -166,7 +175,8 @@ service cloud.firestore {
       
       allow update: if request.auth != null 
                     && (isAdmin() || ('ownerId' in resource.data && request.auth.uid == resource.data.ownerId && checkWriteRate(request.auth.uid)))
-                    && validateEventShape(request.resource.data);
+                    && validateEventShape(request.resource.data)
+                    && (isAdmin() || validateSoftDelete(resource.data, request.resource.data));
                     
       allow delete: if request.auth != null 
                     && (isAdmin() || ('ownerId' in resource.data && request.auth.uid == resource.data.ownerId));


### PR DESCRIPTION
# Description

Implements soft deletes for events. Instead of removing documents from Firestore, setting `deletedAt` to the current timestamp. This preserves historical data and allows admin recovery within 90 days.

Fixes #332

## Changes

### MyEventsScreen.js
- Changed `deleteDoc` to `updateDoc` with `deletedAt: serverTimestamp()`
- Updated confirmation dialog to inform users about 30-day restore window
- Soft-deleted events hidden from owner's event list automatically (deletedAt != null)

### UserFeed.js
- Added `if (data.deletedAt != null) return;` filter alongside existing suspended filter

### MobileAdmin.js
- Added "Deleted" tab to view soft-deleted events
- Added `handleRestoreEvent` that clears `deletedAt` and `deletedBy`
- Active events query excludes soft-deleted documents

### DesktopAdmin.js
- Added Active/Deleted sub-tabs for Events management
- Added Restore button for deleted events
- Uses `deleteField()` to clear deletedAt/deletedBy on restore

### cloud-functions/src/permanentCleanup.ts
- New scheduled function (runs daily) that permanently deletes events with `deletedAt > 90 days`
- Batches deletes in groups of 500 (Firestore batch limit)

### cloud-functions/src/index.ts
- Export the new permanentCleanup function

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Verified Firestore updateDoc calls work with soft-delete pattern
- Confirmed queries filter out deletedAt != null documents
- Batch commit pattern follows existing inactiveUsers cloud function convention

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing delete functionality preserved (soft delete replaces hard delete)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deleted events can now be restored by admins within 90 days
  * Admin dashboards now include a new "Deleted" tab to view and restore deleted events
  * Deleted events are hidden from regular event views
  * Deleted events are automatically permanently removed after 90 days
  * Users receive a message confirming that admins can recover deleted events

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roshankumar0036singh/Uni-Event/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->