### PR TITLE
fix: implement cursor-based pagination for event listing to prevent unbounded data load (#454)

### DIFF
--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -304,10 +304,11 @@ export default function UserFeed() {
     }, [user, isFocused]);
 
     const fetchEventsPage = useCallback(async (cursorDoc) => {
-        const constraints = [orderBy('startAt', 'desc'), limit(PAGE_SIZE + 1)];
+        const constraints = [orderBy('startAt', 'desc')];
         if (cursorDoc) {
-            constraints.unshift(startAfter(cursorDoc));
+            constraints.push(startAfter(cursorDoc));
         }
+        constraints.push(limit(PAGE_SIZE + 1));
         const eventsQuery = query(collection(db, 'events'), ...constraints);
         const snapshot = await getDocs(eventsQuery);
         const docs = snapshot.docs;

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -1,11 +1,21 @@
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
-import { collection, limit, onSnapshot, query, where, getDocs } from 'firebase/firestore';
+import {
+    collection,
+    limit,
+    onSnapshot,
+    query,
+    where,
+    getDocs,
+    orderBy,
+    startAfter,
+} from 'firebase/firestore';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import PropTypes from 'prop-types';
 import {
     Animated,
+    ActivityIndicator,
     Alert,
     Platform,
     ScrollView,
@@ -175,6 +185,8 @@ UserFeedStickyHeader.propTypes = {
     setActiveFilter: PropTypes.func.isRequired,
 };
 
+const PAGE_SIZE = 10;
+
 export default function UserFeed() {
     const { user, userData, role } = useAuth();
     const { theme } = useTheme();
@@ -187,6 +199,9 @@ export default function UserFeed() {
     const [debouncedQuery, setDebouncedQuery] = useState(''); // filtering — 300ms debounced
     const debounceTimer = useRef(null);
     const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+    const lastVisibleRef = useRef(null);
     const [refreshing, setRefreshing] = useState(false);
     const [showFeedbackModal, setShowFeedbackModal] = useState(false);
     const [currentFeedbackRequest, setCurrentFeedbackRequest] = useState(null);
@@ -288,34 +303,63 @@ export default function UserFeed() {
         return () => unsubscribe();
     }, [user, isFocused]);
 
-    useEffect(() => {
+    const fetchEventsPage = useCallback(async (cursorDoc) => {
+        const constraints = [orderBy('startAt', 'desc'), limit(PAGE_SIZE + 1)];
+        if (cursorDoc) {
+            constraints.unshift(startAfter(cursorDoc));
+        }
+        const eventsQuery = query(collection(db, 'events'), ...constraints);
+        const snapshot = await getDocs(eventsQuery);
+        const docs = snapshot.docs;
+        const hasNextPage = docs.length > PAGE_SIZE;
+        const pageDocs = hasNextPage ? docs.slice(0, PAGE_SIZE) : docs;
+        const list = [];
+        pageDocs.forEach(doc => {
+            const data = doc.data();
+            if (data.status === 'suspended') return;
+            if (data.deletedAt != null) return;
+            list.push({ id: doc.id, ...data });
+        });
+        const lastDoc = pageDocs.length > 0 ? pageDocs[pageDocs.length - 1] : null;
+        return { list, lastDoc: lastDoc || null, hasNextPage };
+    }, []);
+
+    const loadInitialEvents = useCallback(async () => {
         if (!user || !isFocused) {
             setLoading(false);
             return;
         }
+        setLoading(true);
+        try {
+            const { list, lastDoc, hasNextPage } = await fetchEventsPage(null);
+            setEvents(list);
+            lastVisibleRef.current = lastDoc;
+            setHasMore(hasNextPage);
+        } catch (error) {
+            console.log('Event Fetch Error', error);
+        } finally {
+            setLoading(false);
+        }
+    }, [user, isFocused, fetchEventsPage]);
 
-        // Fetching events. ideally separate query.
-        const eventsQuery = query(collection(db, 'events'));
+    const loadMore = useCallback(async () => {
+        if (loadingMore || !hasMore) return;
+        setLoadingMore(true);
+        try {
+            const { list, lastDoc, hasNextPage } = await fetchEventsPage(lastVisibleRef.current);
+            setEvents(prev => [...prev, ...list]);
+            lastVisibleRef.current = lastDoc;
+            setHasMore(hasNextPage);
+        } catch (error) {
+            console.log('Load More Error', error);
+        } finally {
+            setLoadingMore(false);
+        }
+    }, [loadingMore, hasMore, fetchEventsPage]);
 
-        const unsubscribe = onSnapshot(
-            eventsQuery,
-            snapshot => {
-                const list = [];
-                snapshot.forEach(doc => {
-                    const data = doc.data();
-                    if (data.status === 'suspended') return;
-                    if (data.deletedAt != null) return;
-                    list.push({ id: doc.id, ...data });
-                });
-                setEvents(list);
-                setLoading(false);
-                setRefreshing(false);
-            },
-            error => console.log('Event Listener Error', error),
-        );
-
-        return () => unsubscribe();
-    }, [role, user, isFocused]);
+    useEffect(() => {
+        loadInitialEvents();
+    }, [loadInitialEvents]);
 
     // Recommendation Logic: Views + User History + Freshness
     const getRecommendedEvents = () => {
@@ -450,23 +494,17 @@ export default function UserFeed() {
         if (!user) return;
         setRefreshing(true);
         try {
-            const refreshEventsQuery = query(collection(db, 'events'));
-            const snapshot = await getDocs(refreshEventsQuery);
-            const list = [];
-            snapshot.forEach(doc => {
-                const data = doc.data();
-                if (data.status === 'suspended') return;
-                if (data.deletedAt != null) return;
-                list.push({ id: doc.id, ...data });
-            });
+            const { list, lastDoc, hasNextPage } = await fetchEventsPage(null);
             setEvents(list);
+            lastVisibleRef.current = lastDoc;
+            setHasMore(hasNextPage);
         } catch (error) {
             console.error('Refresh error:', error);
             Alert.alert('Error', 'Failed to refresh events.');
         } finally {
             setRefreshing(false);
         }
-    }, [user]);
+    }, [user, fetchEventsPage]);
 
     const [pullDistance, setPullDistance] = useState(0);
     const lastPullRef = useRef(0);
@@ -607,6 +645,23 @@ export default function UserFeed() {
                             </Text>
                         </View>
                     }
+                    ListFooterComponent={
+                        hasMore && events.length > 0 ? (
+                            <TouchableOpacity
+                                style={styles.loadMoreBtn}
+                                onPress={loadMore}
+                                disabled={loadingMore}
+                            >
+                                {loadingMore ? (
+                                    <ActivityIndicator color="#fff" />
+                                ) : (
+                                    <Text style={styles.loadMoreText}>Load More</Text>
+                                )}
+                            </TouchableOpacity>
+                        ) : events.length > 0 ? (
+                            <Text style={styles.endText}>You've reached the end</Text>
+                        ) : null
+                    }
                 />
             )}
 
@@ -712,4 +767,20 @@ const styles = StyleSheet.create({
     },
     emptyContainer: { alignItems: 'center', marginTop: 50, padding: 20 },
     emptyText: { marginTop: 10, fontSize: 16 },
+    loadMoreBtn: {
+        backgroundColor: '#6C63FF',
+        paddingVertical: 14,
+        paddingHorizontal: 40,
+        borderRadius: 25,
+        alignSelf: 'center',
+        marginVertical: 20,
+    },
+    loadMoreText: { color: '#fff', fontWeight: '700', fontSize: 15 },
+    endText: {
+        textAlign: 'center',
+        marginVertical: 20,
+        fontSize: 13,
+        opacity: 0.5,
+        color: '#fff',
+    },
 });


### PR DESCRIPTION
## Problem

UserFeed.js used onSnapshot on the full 'events' collection with no limit or pagination. Every document was loaded into memory on screen focus. For large communities with hundreds/thousands of events this caused:

1. Massive initial data download on every screen visit
2. All events retained in React state indefinitely (memory leak)
3. Inefficient in-memory filtering over the full array on every render

## Fix

Replaced the unbounded real-time listener with a cursor-based paginated getDocs pattern:

- **PAGE_SIZE = 10**: each fetch requests PAGE_SIZE + 1 to detect whether a next page exists
- **Load More button**: renders at list bottom; calls startAfter(lastVisibleRef.current) to fetch next page
- **lastVisibleRef**: tracks the last DocumentSnapshot from the previous page as the cursor
- **Pull-to-refresh**: resets to page 1 by fetching without a cursor
- **In-memory filtering preserved**: suspended/deletedAt events still filtered client-side to avoid Firestore composite index requirements
- **Real-time listeners kept**: only the events list was changed to one-shot getDocs; participatingIds and feedbackRequests still use onSnapshot

## Type: Enhancement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated loading in the user feed with cursor-based "Load More" behavior and loading spinner
  * End-of-feed indicator when no more events remain
  * Pull-to-refresh now reloads the first page for consistent pagination

* **Bug Fixes / Improvements**
  * Feed hides suspended or deleted events
  * Pull-to-refresh reports failures via an alert and logs errors
* **Style**
  * New styles for load-more button and end-of-feed text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->