### PR TITLE
chore : enhanced github workflow to perform linting in cloud functions too 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,13 @@ jobs:
                   delete-branch: true
                   labels: dependencies, automated
 
-    # ── App: Lint + Test ─────────────────────────────────────────────
+    # ── App & Cloud Functions: Lint + Test ──────────────────────────
     lint-and-test:
-        name: Lint & Test (app)
+        name: Lint & Test
         runs-on: ubuntu-latest
         permissions:
             contents: write
             pull-requests: write
-        defaults:
-            run:
-                working-directory: ./app
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -68,13 +65,18 @@ jobs:
               with:
                   node-version: '20'
                   cache: npm
-                  cache-dependency-path: app/package-lock.json
+                  cache-dependency-path: '**/package-lock.json'
 
-            - name: Install dependencies
+            - name: Install dependencies (app)
+              working-directory: ./app
+              run: npm ci
+
+            - name: Install dependencies (cloud-functions)
+              working-directory: ./cloud-functions
               run: npm ci
 
             - name: Auto-format with Prettier
-              run: npx prettier --write .
+              run: npx prettier --write app/ cloud-functions/
 
             - name: Create PR for formatted files
               if: github.event_name == 'push'
@@ -90,8 +92,12 @@ jobs:
                   delete-branch: true
                   labels: formatting, automated
 
-            - name: Run ESLint
-              run: npm run lint
+            - name: Run Prettier check
+              run: npx prettier --check app/ cloud-functions/
 
-            - name: Run Jest tests
+            - name: Run ESLint
+              run: npx eslint app/ cloud-functions/
+
+            - name: Run Jest tests (app)
+              working-directory: ./app
               run: npm test -- --ci --passWithNoTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,15 @@ jobs:
               working-directory: ./cloud-functions
               run: npm ci
 
-            - name: Auto-format with Prettier
-              run: npx prettier --write app/ cloud-functions/
+            - name: Auto-format with Prettier (app)
+              if: github.event_name == 'push'
+              working-directory: ./app
+              run: npm run format
+
+            - name: Auto-format with Prettier (cloud-functions)
+              if: github.event_name == 'push'
+              working-directory: ./cloud-functions
+              run: npm run format
 
             - name: Create PR for formatted files
               if: github.event_name == 'push'
@@ -92,11 +99,21 @@ jobs:
                   delete-branch: true
                   labels: formatting, automated
 
-            - name: Run Prettier check
-              run: npx prettier --check app/ cloud-functions/
+            - name: Run Prettier check (app)
+              working-directory: ./app
+              run: npm run format:check
 
-            - name: Run ESLint
-              run: npx eslint app/ cloud-functions/
+            - name: Run Prettier check (cloud-functions)
+              working-directory: ./cloud-functions
+              run: npm run format:check
+
+            - name: Run ESLint (app)
+              working-directory: ./app
+              run: npm run lint
+
+            - name: Run ESLint (cloud-functions)
+              working-directory: ./cloud-functions
+              run: npm run lint
 
             - name: Run Jest tests (app)
               working-directory: ./app

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
         "build:web": "npm run patch-sea && expo export -p web --output-dir web-build",
         "lint": "eslint .",
         "format": "prettier --write .",
+        "format:check": "prettier --check .",
         "generate-sw": "node scripts/generate-sw.js",
         "test": "jest",
         "cypress:open": "cypress open",

--- a/cloud-functions/package.json
+++ b/cloud-functions/package.json
@@ -9,7 +9,8 @@
         "deploy": "firebase deploy --only functions",
         "logs": "firebase functions:log",
         "lint": "eslint .",
-        "format": "prettier --write ."
+        "format": "prettier --write .",
+        "format:check": "prettier --check ."
     },
     "engines": {
         "node": "18"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "test:rules": "firebase emulators:exec --only firestore \"jest tests/firestore.rules.test.ts --runInBand\"",
         "prepare": "husky",
         "lint": "npm run lint --prefix app && npm run lint --prefix cloud-functions",
-        "format": "prettier --check app/ cloud-functions/"
+        "lint:fix": "npm run lint --prefix app -- --fix && npm run lint --prefix cloud-functions -- --fix && prettier --write app/ cloud-functions/"
     },
     "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.1",


### PR DESCRIPTION
# Description

Adds ESLint and Prettier format checks to the CI pipeline so they run automatically on every PR. Previously, the `lint-and-test` job in `.github/workflows/ci.yml` was scoped to `working-directory: ./app`, meaning `cloud-functions` was never linted in CI and formatting issues could slip through undetected.

This updates the CI to install dependencies and run ESLint and Prettier checks across both `app/` and `cloud-functions/` using `working-directory` and `npm run` instead of `npx`, ensuring the locally installed versions are used rather than pulling the latest from the internet. It also adds a `lint:fix` script for local use and fixes the auto-format step to only run on push events so PR checks fail as intended when formatting violations are present.

Fixes #316

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran `npm run lint` and `npm run format:check` locally from the root for both `app/` and `cloud-functions/` to confirm both pass without errors. Verified that the CI workflow triggers correctly on a test PR.

- [x] Lint passes for `app/`
- [x] Lint passes for `cloud-functions/`
- [x] Prettier format check passes for both

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules