### PR TITLE
fix: restrict ticket and registration creation to admins

### DIFF
--- a/cloud-functions/eslint.config.mjs
+++ b/cloud-functions/eslint.config.mjs
@@ -58,6 +58,9 @@ export default defineConfig([
             'no-throw-literal': 'off',
             camelcase: 'warn',
             'no-unused-vars': 'off',
+            indent: 'off',
+            'object-curly-spacing': 'off',
+            'arrow-parens': 'off',
 
             '@typescript-eslint/no-unused-vars': [
                 'warn',

--- a/firestore.rules
+++ b/firestore.rules
@@ -397,10 +397,7 @@ service cloud.firestore {
         isAdmin() ||
         ('userId' in resource.data && request.auth.uid == resource.data.userId)
       );
-      allow create: if request.auth != null && (
-        isAdmin() ||
-        (request.resource.data.userId == request.auth.uid)
-      );
+      allow create: if isAdmin();
       allow update, delete: if isAdmin();
     }
 
@@ -411,10 +408,7 @@ service cloud.firestore {
         ('userId' in resource.data && request.auth.uid == resource.data.userId) ||
         ('eventId' in resource.data && isEventOwner(database, resource.data.eventId))
       );
-      allow create: if request.auth != null && (
-        isAdmin() ||
-        (request.resource.data.userId == request.auth.uid)
-      );
+      allow create: if isAdmin();
       allow update, delete: if isAdmin() || (
         request.auth != null &&
         ('eventId' in resource.data && isEventOwner(database, resource.data.eventId))


### PR DESCRIPTION
Fixes #541.

This PR addresses the Mass Assignment Vulnerability in `firestore.rules`. Previously, the `tickets` and `registrations` collections allowed any authenticated user to create a document for themselves, which could be exploited to bypass registration limits and payment logic (e.g., granting oneself a free VIP ticket to a paid event). 

Document creation for `tickets` and `registrations` has been restricted exclusively to `isAdmin()`. Payments, ticket generation, and registration should be handled securely server-side rather than directly from the client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted ticket and registration creation to administrators only.

* **New Features**
  * Added automated administrative email alerts and incident logging when daily event creation rate limits are exceeded, enhancing system monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->