### PR TITLE
fix: keep registration submit visible above keyboard

### DIFF
--- a/app/src/screens/EventRegistrationFormScreen.js
+++ b/app/src/screens/EventRegistrationFormScreen.js
@@ -8,6 +8,8 @@ import {
     Alert,
     ActivityIndicator,
     Dimensions,
+    KeyboardAvoidingView,
+    Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import ScreenWrapper from '../components/ScreenWrapper';
@@ -327,39 +329,53 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
                 <Text style={styles.headerTitle}>Registration</Text>
             </View>
 
-            <ScrollView contentContainerStyle={styles.content}>
-                <Text style={styles.eventTitle}>{event.title}</Text>
-                <Text style={styles.subtitle}>Please fill out the form below to register.</Text>
-
-                <View style={styles.form}>{event.customFormSchema.map(renderField)}</View>
-
-                <TouchableOpacity
-                    style={[styles.submitBtn, loading && { opacity: 0.7 }]}
-                    onPress={handleSubmit}
-                    disabled={loading}
-                    accessible={true}
-                    accessibilityRole="button"
-                    accessibilityLabel="Submit Registration"
+            <KeyboardAvoidingView
+                testID="registration-keyboard-avoiding-view"
+                style={styles.keyboardAvoidingView}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                keyboardVerticalOffset={Platform.OS === 'ios' ? 16 : 0}
+            >
+                <ScrollView
+                    testID="registration-form-scroll-view"
+                    contentContainerStyle={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                    keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
+                    showsVerticalScrollIndicator={false}
                 >
-                    {loading ? (
-                        <View style={styles.submitLoadingContent}>
-                            <ActivityIndicator color="#fff" />
-                            <Text style={styles.submitBtnText}>Submitting...</Text>
-                        </View>
-                    ) : (
-                        <Text style={styles.submitBtnText}>Submit Registration</Text>
-                    )}
-                </TouchableOpacity>
-            </ScrollView>
+                    <Text style={styles.eventTitle}>{event.title}</Text>
+                    <Text style={styles.subtitle}>Please fill out the form below to register.</Text>
+
+                    <View style={styles.form}>{event.customFormSchema.map(renderField)}</View>
+
+                    <TouchableOpacity
+                        style={[styles.submitBtn, loading && { opacity: 0.7 }]}
+                        onPress={handleSubmit}
+                        disabled={loading}
+                        accessible={true}
+                        accessibilityRole="button"
+                        accessibilityLabel="Submit Registration"
+                    >
+                        {loading ? (
+                            <View style={styles.submitLoadingContent}>
+                                <ActivityIndicator color="#fff" />
+                                <Text style={styles.submitBtnText}>Submitting...</Text>
+                            </View>
+                        ) : (
+                            <Text style={styles.submitBtnText}>Submit Registration</Text>
+                        )}
+                    </TouchableOpacity>
+                </ScrollView>
+            </KeyboardAvoidingView>
         </ScreenWrapper>
     );
 }
 
 const getStyles = theme =>
     StyleSheet.create({
+        keyboardAvoidingView: { flex: 1 },
         header: { flexDirection: 'row', alignItems: 'center', padding: 20, paddingTop: 10 },
         headerTitle: { fontSize: 24, fontWeight: 'bold', color: theme.colors.text, marginLeft: 10 },
-        content: { padding: 20 },
+        content: { flexGrow: 1, padding: 20, paddingBottom: 40 },
         eventTitle: {
             fontSize: 22,
             fontWeight: 'bold',

--- a/app/src/screens/__tests__/EventRegistrationFormScreen.test.js
+++ b/app/src/screens/__tests__/EventRegistrationFormScreen.test.js
@@ -85,7 +85,7 @@ import { render } from '@testing-library/react-native';
 import EventRegistrationFormScreen from '../EventRegistrationFormScreen';
 
 describe('EventRegistrationFormScreen', () => {
-    it('renders registration screen', () => {
+    const renderScreen = () => {
         const route = {
             params: {
                 event: {
@@ -102,11 +102,27 @@ describe('EventRegistrationFormScreen', () => {
             popToTop: jest.fn(),
         };
 
-        const { getByText } = render(
-            <EventRegistrationFormScreen navigation={navigation} route={route} />,
-        );
+        return render(<EventRegistrationFormScreen navigation={navigation} route={route} />);
+    };
+
+    it('renders registration screen', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('Registration')).toBeTruthy();
         expect(getByText('Test Event')).toBeTruthy();
+    });
+
+    it('configures the form to remain accessible when the keyboard opens', () => {
+        const { getByTestId } = renderScreen();
+
+        const keyboardView = getByTestId('registration-keyboard-avoiding-view');
+        const scrollView = getByTestId('registration-form-scroll-view');
+
+        expect(keyboardView).toBeTruthy();
+        expect(scrollView.props.keyboardShouldPersistTaps).toBe('handled');
+        expect(scrollView.props.keyboardDismissMode).toBeDefined();
+        expect(scrollView.props.contentContainerStyle).toEqual(
+            expect.objectContaining({ flexGrow: 1, paddingBottom: 40 }),
+        );
     });
 });


### PR DESCRIPTION
Fixes the registration form layout so the keyboard no longer blocks access to the submit button.

Changes:
- Wraps the form in `KeyboardAvoidingView`
- Keeps the form scrollable while the keyboard is open
- Adds appropriate keyboard dismissal behavior
- Adds bottom spacing for easier submit-button access
- Adds unit coverage for the keyboard-aware layout

Fixes #584

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added tests for the keyboard-aware wrapper and scroll configuration
- [x] Ran the complete Jest test suite: 23 suites and 131 tests passed
- [x] Ran ESLint: 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling on event registration forms to prevent content from being obscured when the on-screen keyboard appears. The form now properly scrolls and adjusts layout for better mobile usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->