### PR TITLE
Fix camera permission deadlock in QR scanner

### DIFF
--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -1,9 +1,12 @@
 import { Ionicons } from '@expo/vector-icons';
-import { Camera } from 'expo-camera';
+import { Camera, CameraView } from 'expo-camera';
 import { doc, getDoc } from 'firebase/firestore';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+    ActivityIndicator,
+    AppState,
     Dimensions,
+    Linking,
     Platform,
     StyleSheet,
     Text,
@@ -91,24 +94,79 @@ export default function QRScannerScreen({ navigation, route }) {
     const [scanned, setScanned] = useState(false);
     const [scanResult, setScanResult] = useState(null); // { status: 'success' | 'error', message: '' }
     const [copied, setCopied] = useState(false);
+    const [canAskPermissionAgain, setCanAskPermissionAgain] = useState(true);
+    const [permissionError, setPermissionError] = useState(false);
     const copyTimeoutRef = useRef(null);
+    const permissionRequestRef = useRef(false);
+    const isMountedRef = useRef(true);
+    const appStateRef = useRef(AppState.currentState);
 
-    useEffect(() => {
-        if (Platform.OS !== 'web') {
-            (async () => {
-                const { status } = await Camera.requestCameraPermissionsAsync();
-                setHasPermission(status === 'granted');
-            })();
-        } else {
+    const requestCameraPermission = useCallback(async () => {
+        if (permissionRequestRef.current) return;
+
+        if (Platform.OS === 'web') {
             setHasPermission(true); // Web handles permission via browser prompt
+            return;
         }
 
+        permissionRequestRef.current = true;
+        setHasPermission(null);
+        setPermissionError(false);
+
+        try {
+            const permission = await Camera.requestCameraPermissionsAsync();
+            if (!isMountedRef.current) return;
+
+            setHasPermission(permission.granted ?? permission.status === 'granted');
+            setCanAskPermissionAgain(permission.canAskAgain !== false);
+        } catch (error) {
+            console.error('Camera permission request failed:', error);
+            if (!isMountedRef.current) return;
+
+            setHasPermission(false);
+            setPermissionError(true);
+        } finally {
+            permissionRequestRef.current = false;
+        }
+    }, []);
+
+    const refreshCameraPermission = useCallback(async () => {
+        if (Platform.OS === 'web') return;
+
+        try {
+            const permission = await Camera.getCameraPermissionsAsync();
+            if (!isMountedRef.current) return;
+
+            setHasPermission(permission.granted ?? permission.status === 'granted');
+            setCanAskPermissionAgain(permission.canAskAgain !== false);
+            setPermissionError(false);
+        } catch (error) {
+            console.error('Unable to refresh camera permission:', error);
+        }
+    }, []);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        requestCameraPermission();
+
+        const appStateSubscription = AppState.addEventListener('change', nextAppState => {
+            const returningToApp =
+                /inactive|background/.test(appStateRef.current) && nextAppState === 'active';
+
+            appStateRef.current = nextAppState;
+            if (returningToApp) {
+                refreshCameraPermission();
+            }
+        });
+
         return () => {
+            isMountedRef.current = false;
+            appStateSubscription.remove();
             if (copyTimeoutRef.current) {
                 clearTimeout(copyTimeoutRef.current);
             }
         };
-    }, []);
+    }, [refreshCameraPermission, requestCameraPermission]);
 
     const handleOfflineCheckIn = async (eventId, scannedUserId, ticketData, userData) => {
         const queued = await queueOfflineCheckIn(eventId, {
@@ -271,17 +329,65 @@ export default function QRScannerScreen({ navigation, route }) {
         }
     };
 
+    const handleOpenSettings = async () => {
+        try {
+            await Linking.openSettings();
+        } catch (error) {
+            console.error('Unable to open app settings:', error);
+            Alert.alert(
+                'Unable to Open Settings',
+                'Open your device settings and enable camera access for UniEvent.',
+            );
+        }
+    };
+
     if (hasPermission === null) {
         return (
             <View style={styles.container}>
+                <ActivityIndicator size="large" />
                 <Text>Requesting camera permission...</Text>
             </View>
         );
     }
     if (hasPermission === false) {
+        const permanentlyDenied = !canAskPermissionAgain && !permissionError;
+
         return (
-            <View style={styles.container}>
-                <Text>No access to camera</Text>
+            <View style={[styles.container, styles.permissionContainer]}>
+                <Ionicons name="camera-outline" size={54} color={theme.colors.primary} />
+                <Text style={[styles.permissionTitle, { color: theme.colors.text }]}>
+                    Camera access required
+                </Text>
+                <Text style={[styles.permissionMessage, { color: theme.colors.textSecondary }]}>
+                    {permanentlyDenied
+                        ? 'Enable camera access in your device settings to scan attendee tickets.'
+                        : 'Allow camera access to scan attendee tickets.'}
+                </Text>
+
+                {permanentlyDenied ? (
+                    <TouchableOpacity
+                        style={[styles.permissionButton, { backgroundColor: theme.colors.primary }]}
+                        onPress={handleOpenSettings}
+                    >
+                        <Text style={styles.permissionButtonText}>Open Settings</Text>
+                    </TouchableOpacity>
+                ) : (
+                    <TouchableOpacity
+                        style={[styles.permissionButton, { backgroundColor: theme.colors.primary }]}
+                        onPress={requestCameraPermission}
+                    >
+                        <Text style={styles.permissionButtonText}>Try Again</Text>
+                    </TouchableOpacity>
+                )}
+
+                <TouchableOpacity
+                    style={styles.permissionBackButton}
+                    onPress={() => navigation.goBack()}
+                >
+                    <Text style={[styles.permissionBackText, { color: theme.colors.primary }]}>
+                        Go Back
+                    </Text>
+                </TouchableOpacity>
             </View>
         );
     }
@@ -302,8 +408,9 @@ export default function QRScannerScreen({ navigation, route }) {
                         style={styles.camera}
                     />
                 ) : (
-                    <Camera
-                        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+                    <CameraView
+                        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+                        onBarcodeScanned={scanned ? undefined : handleBarCodeScanned}
                         style={styles.camera}
                     />
                 )}
@@ -372,6 +479,43 @@ export default function QRScannerScreen({ navigation, route }) {
 
 const styles = StyleSheet.create({
     container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    permissionContainer: {
+        paddingHorizontal: 32,
+    },
+    permissionTitle: {
+        fontSize: 22,
+        fontWeight: '700',
+        marginTop: 18,
+        textAlign: 'center',
+    },
+    permissionMessage: {
+        fontSize: 16,
+        lineHeight: 23,
+        marginTop: 10,
+        textAlign: 'center',
+    },
+    permissionButton: {
+        minWidth: 160,
+        marginTop: 24,
+        paddingHorizontal: 24,
+        paddingVertical: 13,
+        borderRadius: 8,
+        alignItems: 'center',
+    },
+    permissionButtonText: {
+        color: '#fff',
+        fontSize: 16,
+        fontWeight: '700',
+    },
+    permissionBackButton: {
+        marginTop: 10,
+        paddingHorizontal: 24,
+        paddingVertical: 12,
+    },
+    permissionBackText: {
+        fontSize: 16,
+        fontWeight: '600',
+    },
     cameraContainer: { flex: 1, position: 'relative' },
     camera: { flex: 1, width: width },
     overlayHeader: {

--- a/app/src/screens/__tests__/QRScannerScreen.test.js
+++ b/app/src/screens/__tests__/QRScannerScreen.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import { Platform } from 'react-native';
-import { act, render, waitFor } from '@testing-library/react-native';
+import { AppState, Linking, Platform } from 'react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { Camera } from 'expo-camera';
 import { getDoc } from 'firebase/firestore';
 import { checkInAttendee, checkInParticipant, queueOfflineCheckIn } from '../../lib/checkInService';
 import QRScannerScreen from '../QRScannerScreen';
 
 let mockOnBarCodeScanned;
+let mockAppStateChange;
 
 jest.mock('../../lib/checkInService', () => ({
     queueOfflineCheckIn: jest.fn(),
@@ -39,21 +40,31 @@ jest.mock('expo-camera', () => {
     const PropTypes = require('prop-types');
     const { View } = require('react-native');
 
-    const MockCamera = props => {
-        mockOnBarCodeScanned = props.onBarCodeScanned;
+    const MockCameraView = props => {
+        mockOnBarCodeScanned = props.onBarcodeScanned;
         return React.createElement(View, { testID: 'camera' });
     };
-    MockCamera.propTypes = {
-        onBarCodeScanned: PropTypes.func,
+    MockCameraView.propTypes = {
+        onBarcodeScanned: PropTypes.func,
     };
 
-    MockCamera.requestCameraPermissionsAsync = jest.fn(() =>
-        Promise.resolve({
-            status: 'denied',
-        }),
-    );
+    const MockCamera = {
+        requestCameraPermissionsAsync: jest.fn(() =>
+            Promise.resolve({
+                status: 'denied',
+            }),
+        ),
+        getCameraPermissionsAsync: jest.fn(() =>
+            Promise.resolve({
+                status: 'denied',
+            }),
+        ),
+    };
 
-    return { Camera: MockCamera };
+    return {
+        Camera: MockCamera,
+        CameraView: MockCameraView,
+    };
 });
 
 jest.mock('firebase/firestore', () => ({
@@ -106,8 +117,20 @@ beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'log').mockImplementation(() => {});
     mockOnBarCodeScanned = undefined;
+    mockAppStateChange = undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, callback) => {
+        mockAppStateChange = callback;
+        return { remove: jest.fn() };
+    });
     Camera.requestCameraPermissionsAsync.mockResolvedValue({
         status: 'denied',
+        granted: false,
+        canAskAgain: true,
+    });
+    Camera.getCameraPermissionsAsync.mockResolvedValue({
+        status: 'denied',
+        granted: false,
+        canAskAgain: true,
     });
 });
 
@@ -116,7 +139,19 @@ afterEach(() => {
 });
 
 describe('QRScannerScreen', () => {
-    it('shows no camera access message when permission denied', async () => {
+    it('allows retrying when camera permission can be requested again', async () => {
+        Camera.requestCameraPermissionsAsync
+            .mockResolvedValueOnce({
+                status: 'denied',
+                granted: false,
+                canAskAgain: true,
+            })
+            .mockResolvedValueOnce({
+                status: 'granted',
+                granted: true,
+                canAskAgain: true,
+            });
+
         const route = {
             params: {
                 eventId: '1',
@@ -128,10 +163,126 @@ describe('QRScannerScreen', () => {
             goBack: jest.fn(),
         };
 
-        const { getByText } = render(<QRScannerScreen navigation={navigation} route={route} />);
+        const { getByText, getByTestId } = render(
+            <QRScannerScreen navigation={navigation} route={route} />,
+        );
 
         await waitFor(() => {
-            expect(getByText(/no access to camera/i)).toBeTruthy();
+            expect(getByText('Try Again')).toBeTruthy();
+        });
+
+        fireEvent.press(getByText('Try Again'));
+
+        await waitFor(() => {
+            expect(Camera.requestCameraPermissionsAsync).toHaveBeenCalledTimes(2);
+            expect(getByTestId('camera')).toBeTruthy();
+        });
+    });
+
+    it('opens device settings when camera permission cannot be requested again', async () => {
+        Camera.requestCameraPermissionsAsync.mockResolvedValueOnce({
+            status: 'denied',
+            granted: false,
+            canAskAgain: false,
+        });
+        jest.spyOn(Linking, 'openSettings').mockResolvedValue();
+
+        const navigation = {
+            goBack: jest.fn(),
+        };
+        const route = {
+            params: {
+                eventId: '1',
+                eventTitle: 'Test Event',
+            },
+        };
+
+        const { getByText, queryByText } = render(
+            <QRScannerScreen navigation={navigation} route={route} />,
+        );
+
+        await waitFor(() => {
+            expect(getByText('Open Settings')).toBeTruthy();
+            expect(queryByText('Try Again')).toBeNull();
+        });
+
+        fireEvent.press(getByText('Open Settings'));
+        expect(Linking.openSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes camera permission after returning from device settings', async () => {
+        Camera.requestCameraPermissionsAsync.mockResolvedValueOnce({
+            status: 'denied',
+            granted: false,
+            canAskAgain: false,
+        });
+        Camera.getCameraPermissionsAsync.mockResolvedValueOnce({
+            status: 'granted',
+            granted: true,
+            canAskAgain: true,
+        });
+
+        const navigation = {
+            goBack: jest.fn(),
+        };
+        const route = {
+            params: {
+                eventId: '1',
+                eventTitle: 'Test Event',
+            },
+        };
+
+        const { getByText, getByTestId } = render(
+            <QRScannerScreen navigation={navigation} route={route} />,
+        );
+
+        await waitFor(() => {
+            expect(getByText('Open Settings')).toBeTruthy();
+        });
+
+        act(() => {
+            mockAppStateChange('background');
+            mockAppStateChange('active');
+        });
+
+        await waitFor(() => {
+            expect(Camera.getCameraPermissionsAsync).toHaveBeenCalledTimes(1);
+            expect(getByTestId('camera')).toBeTruthy();
+        });
+    });
+
+    it('recovers from a failed camera permission request', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        Camera.requestCameraPermissionsAsync
+            .mockRejectedValueOnce(new Error('Permission request failed'))
+            .mockResolvedValueOnce({
+                status: 'granted',
+                granted: true,
+                canAskAgain: true,
+            });
+
+        const navigation = {
+            goBack: jest.fn(),
+        };
+        const route = {
+            params: {
+                eventId: '1',
+                eventTitle: 'Test Event',
+            },
+        };
+
+        const { getByText, getByTestId } = render(
+            <QRScannerScreen navigation={navigation} route={route} />,
+        );
+
+        await waitFor(() => {
+            expect(getByText('Try Again')).toBeTruthy();
+        });
+
+        fireEvent.press(getByText('Try Again'));
+
+        await waitFor(() => {
+            expect(getByTestId('camera')).toBeTruthy();
         });
     });
 
@@ -139,6 +290,8 @@ describe('QRScannerScreen', () => {
         jest.spyOn(console, 'warn').mockImplementation(() => {});
         Camera.requestCameraPermissionsAsync.mockResolvedValueOnce({
             status: 'granted',
+            granted: true,
+            canAskAgain: true,
         });
         getDoc.mockResolvedValueOnce({
             exists: () => false,


### PR DESCRIPTION
## Summary

Fixes #581

- prevents overlapping camera permission requests
- provides retry handling for temporary permission denial
- directs users to device settings after permanent denial
- refreshes permission automatically when returning to the app
- handles permission request and settings errors gracefully
- updates scanner rendering to use `CameraView` for Expo SDK 52
- cleans up AppState listeners when the screen unmounts

## Testing

- Added tests for retrying permission requests
- Added tests for permanent denial and opening settings
- Added tests for permission recovery after returning to the app
- Added tests for permission request failures
- Verified QR scanning still works after permission is granted

## Verification

- 23 test suites passed
- 134 tests passed
- ESLint: 0 errors
- Manually tested on Android Pixel 8 emulator

## Screenshots

### Permanent permission denial
<img width="573" height="1000" alt="camera-permission-open-settings" src="https://github.com/user-attachments/assets/9b8239d6-fbc5-458f-b58e-c549d8a09c3e" />


### Scanner after granting permission
<img width="573" height="1000" alt="camera-permission-recovered-scanner" src="https://github.com/user-attachments/assets/e83a494d-e107-41e7-8e6c-8712370da995" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shortcut to device settings when camera permissions are permanently denied
  * Implemented automatic permission refresh when the app returns to the foreground
  * Enhanced "Try Again" button to retry camera permission requests

* **Bug Fixes**
  * Improved camera permission handling robustness across platforms and app lifecycle events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->