### PR TITLE
fix: return JSON response for missing email templates

### DIFF
--- a/cloud-functions/src/server.ts
+++ b/cloud-functions/src/server.ts
@@ -331,12 +331,12 @@ app.get('/email-preview/:templateName', (req: express.Request, res: express.Resp
         res.send(responseHtml); // NOSONAR
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Unknown error';
-        const errorHtml = `
-      <h1>Template Not Found</h1>
-      <p>${escHtml(message)}</p>
-      <a href="/email-preview">← Back to template list</a>
-    `;
-        res.status(404).send(errorHtml); // NOSONAR
+
+        return res.status(404).json({
+            success: false,
+            error: 'Template not found',
+            message,
+        });
     }
 });
 


### PR DESCRIPTION
## Description

Fixes #612

### Changes Made

* Replaced HTML error response with a structured JSON response for missing email templates.
* Preserved HTTP 404 status code.
* Improved API consistency for clients consuming the endpoint.

### Before

```json
HTML response:
<h1>Template Not Found</h1>
```

### After

```json
{
  "success": false,
  "error": "Template not found"
}
```

### Testing

* Verified the endpoint returns HTTP 404.
* Verified response format is JSON.
* Confirmed error handling remains functional.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email preview API error responses have been updated to return standardized JSON format instead of HTML when a requested template is not found. This ensures consistent error handling across the platform, with responses now including success status indicators and detailed error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->