### PR TITLE
fix: fail loud on malformed GOOGLE_APPLICATION_CREDENTIALS_JSON

### DIFF
--- a/cloud-functions/src/server.ts
+++ b/cloud-functions/src/server.ts
@@ -21,9 +21,10 @@ if (admin.apps.length === 0) {
             });
             console.log('✅ Firebase Admin initialized with service account from env');
         } catch (error) {
-            console.error('❌ Failed to parse service account JSON:', error);
-            admin.initializeApp();
+            console.error('❌ Failed to parse GOOGLE_APPLICATION_CREDENTIALS_JSON. Refusing to fall back to default credentials.', error);
+            throw new Error('Invalid GOOGLE_APPLICATION_CREDENTIALS_JSON: malformed JSON');
         }
+
     } else {
         // Fallback to default credentials
         admin.initializeApp();


### PR DESCRIPTION
## Description

This PR resolves the issue where the Firebase Admin SDK initialization fails silently when `GOOGLE_APPLICATION_CREDENTIALS_JSON` contains a malformed or invalid JSON string.

Instead of catching the error and silently falling back to default application credentials—which risks deploying with unintended or incorrect privileges in production—the initialization logic in `cloud-functions/src/server.ts` has been updated to explicitly catch parse failures and throw a critical error to fail loudly.

## Related Issue

Fixes #[[613](https://github.com/roshankumar0036singh/Uni-Event/issues/613)](https://github.com/roshankumar0036singh/Uni-Event/issues/613)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

1. Configured `GOOGLE_APPLICATION_CREDENTIALS_JSON` with an intentionally malformed JSON string.
2. Ran the backend Cloud Function environment locally.
3. Verified that the process terminates and throws a clear initialization/parse error rather than silently bypassing the configuration.

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] A clear error is thrown when configuration parsing fails

---

### 💡 GSSoC Reminder

When you create this PR, don't forget to ask the maintainer or use the repository's labels to apply:

* `gssoc-ext` / `gssoc`
* `bug`
* `level1`, `level2`, or `level3` (depending on their difficulty assessment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during application initialization to properly validate configuration and reject malformed data instead of silently falling back to defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->