### PR TITLE
feat: reward users with points for event attendance

### DIFF
--- a/cloud-functions/src/attendanceStreak.ts
+++ b/cloud-functions/src/attendanceStreak.ts
@@ -3,6 +3,8 @@ import { onDocumentCreated } from 'firebase-functions/v2/firestore';
 import { awardDedicatedStudentCertificate } from './dedicatedStudentCertificate';
 import { Timestamp } from '@google-cloud/firestore';
 
+const ATTENDANCE_POINTS_REWARD = 10;
+
 function getISOWeekKey(date: Date): string {
     const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
     d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
@@ -62,6 +64,7 @@ export const attendanceStreak = onDocumentCreated(
                 currentStreak: newStreak,
                 longestStreak: newLongestStreak,
                 lastAttendanceAt: now,
+                points: admin.firestore.FieldValue.increment(ATTENDANCE_POINTS_REWARD),
             });
 
             console.log('previous currentStreak:', currentStreak);


### PR DESCRIPTION
## Summary

Adds attendance-based point rewards using the existing attendance streak cloud function.

### Changes

* Added `ATTENDANCE_POINTS_REWARD` constant.
* Awards 10 points when a user successfully attends an event.
* Rewards are granted server-side through the attendance streak trigger.
* Preserves the existing weekly streak logic and prevents duplicate rewards within the same week.

### Result

Users now earn points not only for RSVPing to events, but also for actually attending them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now earn points for each attendance check-in (10 points per check-in).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->