### PR TITLE
feat : save event as save later

### DIFF
--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -3,11 +3,15 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import * as ImagePicker from 'expo-image-picker';
 import {
     collection,
+    getDocs,
     updateDoc,
     doc,
+    query,
     runTransaction,
     increment,
     serverTimestamp,
+    setDoc,
+    where,
 } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -15,6 +19,7 @@ import {
     ActivityIndicator,
     Alert,
     Image,
+    Modal,
     Platform,
     ScrollView,
     StyleSheet,
@@ -60,6 +65,9 @@ export default function CreateEvent({ navigation, route }) {
     const styles = useMemo(() => getStyles(theme), [theme]);
 
     const [loading, setLoading] = useState(false);
+    const [templateLoading, setTemplateLoading] = useState(false);
+    const [templateModalVisible, setTemplateModalVisible] = useState(false);
+    const [templates, setTemplates] = useState([]);
 
     // Form State
     const [title, setTitle] = useState('');
@@ -186,7 +194,7 @@ export default function CreateEvent({ navigation, route }) {
         else setTargetYears([...targetYears, y]);
     };
 
-    const { event } = route.params || {};
+    const { event, template } = route.params || {};
     const isEditMode = !!event;
     let submitLabel = isEditMode ? 'Update Event' : 'Create Event';
     if (loading) {
@@ -223,6 +231,116 @@ export default function CreateEvent({ navigation, route }) {
         );
     };
 
+    const applyTemplate = selectedTemplate => {
+        if (!selectedTemplate) return;
+
+        setTitle(selectedTemplate.title || '');
+        setDescription(selectedTemplate.description || '');
+        setSelectedTags(selectedTemplate.tags || []);
+        setCategory(selectedTemplate.category || '');
+        setLocation(selectedTemplate.location || '');
+        setCoordinates(selectedTemplate.coordinates || null);
+        setTargetBranches(selectedTemplate.target?.departments || ['All']);
+        setTargetYears(selectedTemplate.target?.years || []);
+        setEventMode(selectedTemplate.eventMode || 'offline');
+        setMeetLink(selectedTemplate.meetLink || '');
+        setIsPaid(!!selectedTemplate.isPaid);
+        setPrice(selectedTemplate.price?.toString() || '');
+        setUpiId(selectedTemplate.upiId || '');
+        setRegistrationLink(selectedTemplate.registrationLink || '');
+        setImageUri(selectedTemplate.bannerUrl || null);
+        setCapacity(selectedTemplate.capacity?.toString() || '');
+        setUseCustomForm(!!selectedTemplate.hasCustomForm);
+        setCustomFormSchema(selectedTemplate.customFormSchema || []);
+        setTemplateModalVisible(false);
+    };
+
+    const fetchTemplates = async () => {
+        if (!user?.uid) {
+            Alert.alert('Login Required', 'Please login to use event templates.');
+            return;
+        }
+
+        setTemplateLoading(true);
+        try {
+            const templatesQuery = query(
+                collection(db, 'eventTemplates'),
+                where('ownerId', '==', user.uid),
+            );
+            const snapshot = await getDocs(templatesQuery);
+            const nextTemplates = snapshot.docs
+                .map(templateDoc => ({ id: templateDoc.id, ...templateDoc.data() }))
+                .sort((a, b) => {
+                    const left = a.createdAt?.toMillis?.() || 0;
+                    const right = b.createdAt?.toMillis?.() || 0;
+                    return right - left;
+                });
+
+            setTemplates(nextTemplates);
+            setTemplateModalVisible(true);
+        } catch (error) {
+            console.error('Template fetch failed:', error);
+            Alert.alert('Error', 'Failed to load templates.');
+        } finally {
+            setTemplateLoading(false);
+        }
+    };
+
+    const saveAsTemplate = async () => {
+        if (loading || templateLoading) return;
+
+        if (!user?.uid) {
+            Alert.alert('Login Required', 'Please login to save templates.');
+            return;
+        }
+        if (!title.trim() || !description.trim() || !category) {
+            Alert.alert('Missing Info', 'Please fill Title, Description and Category.');
+            return;
+        }
+
+        setTemplateLoading(true);
+        try {
+            const templateData = {
+                title: title.trim(),
+                description: description.trim(),
+                tags: selectedTags,
+                category,
+                location: eventMode === 'online' ? 'Google Meet' : location,
+                coordinates: eventMode === 'offline' && coordinates ? coordinates : null,
+                eventMode,
+                meetLink: eventMode === 'online' ? meetLink : null,
+                isPaid,
+                price: isPaid ? Math.max(0, Number.parseFloat(price) || 0) : 0,
+                upiId: isPaid ? upiId : null,
+                registrationLink,
+                target: {
+                    departments: targetBranches,
+                    years: targetYears.length ? targetYears : [1, 2, 3, 4],
+                },
+                bannerUrl: imageUri?.startsWith('http') ? imageUri : null,
+                capacity: capacity ? Number.parseInt(capacity, 10) : null,
+                hasCustomForm: useCustomForm,
+                customFormSchema: useCustomForm ? customFormSchema : [],
+                type: 'eventTemplate',
+                ownerId: user.uid,
+                ownerEmail: user.email,
+                organizerName: user.displayName || 'Club Admin',
+                createdAt: serverTimestamp(),
+                updatedAt: serverTimestamp(),
+            };
+
+            const templateRef = doc(collection(db, 'eventTemplates'));
+            await setDoc(templateRef, templateData);
+
+            Alert.alert('Saved', 'Template saved successfully!');
+        } catch (error) {
+            console.error('Template save failed:', error);
+            Alert.alert('Error', 'Failed to save template.');
+        } finally {
+            setTemplateLoading(false);
+        }
+    };
+
     useEffect(() => {
         if (isEditMode) {
             setTitle(event.title);
@@ -246,8 +364,10 @@ export default function CreateEvent({ navigation, route }) {
             setUseCustomForm(event.hasCustomForm);
             setCustomFormSchema(event.customFormSchema || []);
             navigation.setOptions({ title: 'Edit Event' });
+        } else if (template) {
+            applyTemplate(template);
         }
-    }, [isEditMode, event, navigation]);
+    }, [isEditMode, event, template, navigation]);
 
     const handleCreate = async () => {
         if (loading) return;
@@ -513,6 +633,32 @@ export default function CreateEvent({ navigation, route }) {
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
             >
+                <View style={styles.templateActions}>
+                    {!isEditMode && (
+                        <TouchableOpacity
+                            style={[styles.templateBtn, templateLoading && styles.disabledControl]}
+                            onPress={fetchTemplates}
+                            disabled={loading || templateLoading}
+                        >
+                            <Ionicons name="copy-outline" size={18} color={theme.colors.primary} />
+                            <Text style={styles.templateBtnText}>
+                                {templateLoading ? 'Loading Templates...' : 'Use Template'}
+                            </Text>
+                        </TouchableOpacity>
+                    )}
+
+                    <TouchableOpacity
+                        style={[styles.templateBtn, templateLoading && styles.disabledControl]}
+                        onPress={saveAsTemplate}
+                        disabled={loading || templateLoading}
+                    >
+                        <Ionicons name="bookmark-outline" size={18} color={theme.colors.primary} />
+                        <Text style={styles.templateBtnText}>
+                            {templateLoading ? 'Saving...' : 'Save as Template'}
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+
                 {/* Banner Picker - Immersive Style */}
                 <TouchableOpacity
                     style={[styles.bannerPicker, loading && styles.disabledControl]}
@@ -1048,6 +1194,67 @@ export default function CreateEvent({ navigation, route }) {
 
                 <View style={{ height: 100 }} />
             </ScrollView>
+
+            <Modal
+                visible={templateModalVisible}
+                transparent
+                animationType="slide"
+                onRequestClose={() => setTemplateModalVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.templateModal}>
+                        <View style={styles.templateModalHeader}>
+                            <View>
+                                <Text style={styles.templateModalTitle}>Event Templates</Text>
+                                <Text style={styles.templateModalSubtitle}>
+                                    Pick one to prefill this event.
+                                </Text>
+                            </View>
+                            <TouchableOpacity onPress={() => setTemplateModalVisible(false)}>
+                                <Ionicons name="close" size={24} color={theme.colors.text} />
+                            </TouchableOpacity>
+                        </View>
+
+                        <ScrollView showsVerticalScrollIndicator={false}>
+                            {templates.length === 0 ? (
+                                <View style={styles.emptyTemplates}>
+                                    <Ionicons
+                                        name="documents-outline"
+                                        size={32}
+                                        color={theme.colors.textSecondary}
+                                    />
+                                    <Text style={styles.emptyTemplatesText}>
+                                        No templates saved yet.
+                                    </Text>
+                                </View>
+                            ) : (
+                                templates.map(savedTemplate => (
+                                    <TouchableOpacity
+                                        key={savedTemplate.id}
+                                        style={styles.templateItem}
+                                        onPress={() => applyTemplate(savedTemplate)}
+                                    >
+                                        <View style={{ flex: 1 }}>
+                                            <Text style={styles.templateItemTitle}>
+                                                {savedTemplate.title}
+                                            </Text>
+                                            <Text style={styles.templateItemMeta}>
+                                                {savedTemplate.category || 'General'} -{' '}
+                                                {savedTemplate.eventMode || 'offline'}
+                                            </Text>
+                                        </View>
+                                        <Ionicons
+                                            name="chevron-forward"
+                                            size={18}
+                                            color={theme.colors.textSecondary}
+                                        />
+                                    </TouchableOpacity>
+                                ))
+                            )}
+                        </ScrollView>
+                    </View>
+                </View>
+            </Modal>
         </ScreenWrapper>
     );
 }
@@ -1058,6 +1265,32 @@ const getStyles = theme =>
         backBtn: { marginRight: 15 },
         headerTitle: { fontSize: 24, fontWeight: 'bold', color: theme.colors.text },
         scrollContent: { padding: 20, paddingTop: 0 },
+
+        templateActions: {
+            flexDirection: 'row',
+            gap: 10,
+            marginBottom: 18,
+        },
+        templateBtn: {
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+            borderRadius: 12,
+            paddingVertical: 12,
+            paddingHorizontal: 10,
+            minHeight: 48,
+        },
+        templateBtnText: {
+            color: theme.colors.primary,
+            fontWeight: '700',
+            fontSize: 13,
+            textAlign: 'center',
+        },
 
         bannerPicker: {
             height: 200,
@@ -1199,6 +1432,68 @@ const getStyles = theme =>
         },
         disabledControl: {
             opacity: 0.65,
+        },
+
+        modalOverlay: {
+            flex: 1,
+            justifyContent: 'flex-end',
+            backgroundColor: 'rgba(0,0,0,0.45)',
+        },
+        templateModal: {
+            maxHeight: '72%',
+            backgroundColor: theme.colors.background,
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
+            padding: 20,
+        },
+        templateModalHeader: {
+            flexDirection: 'row',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 16,
+            marginBottom: 16,
+        },
+        templateModalTitle: {
+            color: theme.colors.text,
+            fontSize: 20,
+            fontWeight: '800',
+        },
+        templateModalSubtitle: {
+            color: theme.colors.textSecondary,
+            fontSize: 13,
+            marginTop: 4,
+        },
+        emptyTemplates: {
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingVertical: 36,
+            gap: 10,
+        },
+        emptyTemplatesText: {
+            color: theme.colors.textSecondary,
+            fontWeight: '600',
+        },
+        templateItem: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 12,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+            borderRadius: 12,
+            padding: 14,
+            marginBottom: 10,
+        },
+        templateItemTitle: {
+            color: theme.colors.text,
+            fontWeight: '800',
+            fontSize: 15,
+        },
+        templateItemMeta: {
+            color: theme.colors.textSecondary,
+            fontSize: 12,
+            marginTop: 4,
+            textTransform: 'capitalize',
         },
 
         // Capacity Warning

--- a/app/src/screens/__tests__/CreateEvent.test.js
+++ b/app/src/screens/__tests__/CreateEvent.test.js
@@ -112,7 +112,7 @@ jest.mock('../../lib/capacityPredictor', () => ({
     predictAttendance: jest.fn(() => null),
 }));
 
-const mockEnforceRateLimit = jest.fn(async () => {});
+const mockEnforceRateLimit = jest.fn(async () => { });
 jest.mock('../../lib/rateLimiter', () => ({
     enforceRateLimit: (...args) => mockEnforceRateLimit(...args),
 }));
@@ -142,6 +142,11 @@ const mockRunTransaction = jest.fn(async (dbArg, callback) => {
     return callback(tx);
 });
 
+const mockSetDoc = jest.fn(async () => { });
+const mockGetDocs = jest.fn(async () => ({ docs: [] }));
+const mockWhere = jest.fn((...args) => ({ __isWhereClause: true, args }));
+const mockQuery = jest.fn((...args) => ({ __isQuery: true, args }));
+
 const mockCollection = jest.fn((dbArg, ...segments) => ({
     __isCollectionRef: true,
     path: segments.join('/'),
@@ -163,6 +168,10 @@ const mockDoc = jest.fn((firstArg, ...segments) => {
 jest.mock('firebase/firestore', () => ({
     collection: (...args) => mockCollection(...args),
     doc: (...args) => mockDoc(...args),
+    getDocs: (...args) => mockGetDocs(...args),
+    setDoc: (...args) => mockSetDoc(...args),
+    where: (...args) => mockWhere(...args),
+    query: (...args) => mockQuery(...args),
     updateDoc: jest.fn(),
     runTransaction: (...args) => mockRunTransaction(...args),
     increment: (...args) => mockIncrement(...args),
@@ -186,7 +195,7 @@ describe('CreateEvent transaction flow', () => {
         };
         const route = { params: {} };
 
-        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
 
         const { getByPlaceholderText, getByText, getAllByText } = render(
             <CreateEvent navigation={navigation} route={route} />,
@@ -253,5 +262,239 @@ describe('CreateEvent transaction flow', () => {
         });
 
         alertSpy.mockRestore();
+    });
+});
+
+describe('CreateEvent – saveAsTemplate', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('saves a template to Firestore with correct fields', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+
+        const { getByPlaceholderText, getByText } = render(
+            <CreateEvent navigation={navigation} route={route} />,
+        );
+
+        fireEvent.changeText(getByPlaceholderText('e.g. Annual Tech Symposium'), 'Hackathon Night');
+        fireEvent.changeText(
+            getByPlaceholderText('What is this event about?'),
+            'An overnight coding competition.',
+        );
+        fireEvent.press(getByText('Tech'));
+
+        fireEvent.press(getByText('Save as Template'));
+
+        await waitFor(() => {
+            expect(mockSetDoc).toHaveBeenCalledTimes(1);
+        });
+
+        const [, templateData] = mockSetDoc.mock.calls[0];
+        expect(templateData).toMatchObject({
+            title: 'Hackathon Night',
+            description: 'An overnight coding competition.',
+            category: 'Tech',
+            type: 'eventTemplate',
+            ownerId: 'organizer-1',
+            ownerEmail: 'organizer@example.com',
+            organizerName: 'Organizer One',
+        });
+        expect(templateData.createdAt).toEqual({ __op: 'serverTimestamp' });
+        expect(templateData.updatedAt).toEqual({ __op: 'serverTimestamp' });
+
+        await waitFor(() => {
+            expect(alertSpy).toHaveBeenCalledWith('Saved', 'Template saved successfully!');
+        });
+
+        alertSpy.mockRestore();
+    });
+
+    it('shows validation alert when required fields are missing', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+
+        const { getByText } = render(<CreateEvent navigation={navigation} route={route} />);
+
+        // Press without filling anything
+        fireEvent.press(getByText('Save as Template'));
+
+        await waitFor(() => {
+            expect(alertSpy).toHaveBeenCalledWith(
+                'Missing Info',
+                'Please fill Title, Description and Category.',
+            );
+        });
+        expect(mockSetDoc).not.toHaveBeenCalled();
+
+        alertSpy.mockRestore();
+    });
+});
+
+describe('CreateEvent – fetchTemplates and applyTemplate', () => {
+    const MOCK_TEMPLATES = [
+        {
+            id: 'tpl-1',
+            title: 'Annual Hackathon',
+            description: 'Overnight coding competition.',
+            category: 'Tech',
+            eventMode: 'offline',
+            location: 'Auditorium',
+            tags: ['hackathon', 'coding'],
+            target: { departments: ['CSE'], years: [1, 2] },
+            isPaid: false,
+            price: 0,
+            capacity: 150,
+            hasCustomForm: false,
+            customFormSchema: [],
+            createdAt: { toMillis: () => 1000 },
+        },
+        {
+            id: 'tpl-2',
+            title: 'Cultural Fest',
+            description: 'Annual cultural event.',
+            category: 'Cultural',
+            eventMode: 'offline',
+            location: 'Main Ground',
+            tags: [],
+            target: { departments: ['All'], years: [1, 2, 3, 4] },
+            isPaid: true,
+            price: 50,
+            capacity: 500,
+            hasCustomForm: false,
+            customFormSchema: [],
+            createdAt: { toMillis: () => 2000 },
+        },
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetDocs.mockResolvedValue({
+            docs: MOCK_TEMPLATES.map(t => ({
+                id: t.id,
+                data: () => t,
+            })),
+        });
+    });
+
+    it('opens the template modal and lists saved templates', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+
+        const { getByText } = render(<CreateEvent navigation={navigation} route={route} />);
+
+        fireEvent.press(getByText('Use Template'));
+
+        await waitFor(() => {
+            expect(mockGetDocs).toHaveBeenCalledTimes(1);
+            expect(getByText('Annual Hackathon')).toBeTruthy();
+            expect(getByText('Cultural Fest')).toBeTruthy();
+        });
+    });
+
+    it('queries Firestore by the current user\'s ownerId', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+
+        const { getByText } = render(<CreateEvent navigation={navigation} route={route} />);
+        fireEvent.press(getByText('Use Template'));
+
+        await waitFor(() => {
+            expect(mockWhere).toHaveBeenCalledWith('ownerId', '==', 'organizer-1');
+            expect(mockGetDocs).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('pre-fills form fields when a template is selected from the modal', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+
+        const { getByText, getByDisplayValue } = render(
+            <CreateEvent navigation={navigation} route={route} />,
+        );
+
+        fireEvent.press(getByText('Use Template'));
+
+        await waitFor(() => {
+            expect(getByText('Annual Hackathon')).toBeTruthy();
+        });
+
+        // Tap the first template
+        fireEvent.press(getByText('Annual Hackathon'));
+
+        await waitFor(() => {
+            expect(getByDisplayValue('Annual Hackathon')).toBeTruthy();
+            expect(getByDisplayValue('Overnight coding competition.')).toBeTruthy();
+        });
+    });
+
+    it('shows empty-state message when no templates exist', async () => {
+        mockGetDocs.mockResolvedValue({ docs: [] });
+
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+
+        const { getByText } = render(<CreateEvent navigation={navigation} route={route} />);
+
+        fireEvent.press(getByText('Use Template'));
+
+        await waitFor(() => {
+            expect(getByText('No templates saved yet.')).toBeTruthy();
+        });
+    });
+
+    it('shows error alert when getDocs throws', async () => {
+        mockGetDocs.mockRejectedValue(new Error('Network error'));
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+
+        const { getByText } = render(<CreateEvent navigation={navigation} route={route} />);
+
+        fireEvent.press(getByText('Use Template'));
+
+        await waitFor(() => {
+            expect(alertSpy).toHaveBeenCalledWith('Error', 'Failed to load templates.');
+        });
+
+        alertSpy.mockRestore();
+    });
+});
+
+describe('CreateEvent – applyTemplate via route.params', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('pre-fills all form fields from a template passed in route.params', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const templateParam = {
+            title: 'Workshop on AI',
+            description: 'Intro to machine learning.',
+            category: 'Workshop',
+            eventMode: 'offline',
+            location: 'Lab 4',
+            tags: ['AI', 'ML'],
+            target: { departments: ['CSE', 'ETC'], years: [3, 4] },
+            isPaid: false,
+            price: 0,
+            capacity: 60,
+            hasCustomForm: false,
+            customFormSchema: [],
+        };
+        const route = { params: { template: templateParam } };
+
+        const { getByDisplayValue } = render(
+            <CreateEvent navigation={navigation} route={route} />,
+        );
+
+        await waitFor(() => {
+            expect(getByDisplayValue('Workshop on AI')).toBeTruthy();
+            expect(getByDisplayValue('Intro to machine learning.')).toBeTruthy();
+        });
     });
 });

--- a/app/src/screens/__tests__/CreateEvent.test.js
+++ b/app/src/screens/__tests__/CreateEvent.test.js
@@ -112,7 +112,7 @@ jest.mock('../../lib/capacityPredictor', () => ({
     predictAttendance: jest.fn(() => null),
 }));
 
-const mockEnforceRateLimit = jest.fn(async () => { });
+const mockEnforceRateLimit = jest.fn(async () => {});
 jest.mock('../../lib/rateLimiter', () => ({
     enforceRateLimit: (...args) => mockEnforceRateLimit(...args),
 }));
@@ -142,7 +142,7 @@ const mockRunTransaction = jest.fn(async (dbArg, callback) => {
     return callback(tx);
 });
 
-const mockSetDoc = jest.fn(async () => { });
+const mockSetDoc = jest.fn(async () => {});
 const mockGetDocs = jest.fn(async () => ({ docs: [] }));
 const mockWhere = jest.fn((...args) => ({ __isWhereClause: true, args }));
 const mockQuery = jest.fn((...args) => ({ __isQuery: true, args }));
@@ -195,7 +195,7 @@ describe('CreateEvent transaction flow', () => {
         };
         const route = { params: {} };
 
-        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
         const { getByPlaceholderText, getByText, getAllByText } = render(
             <CreateEvent navigation={navigation} route={route} />,
@@ -273,7 +273,7 @@ describe('CreateEvent – saveAsTemplate', () => {
     it('saves a template to Firestore with correct fields', async () => {
         const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
         const route = { params: {} };
-        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
         const { getByPlaceholderText, getByText } = render(
             <CreateEvent navigation={navigation} route={route} />,
@@ -315,7 +315,7 @@ describe('CreateEvent – saveAsTemplate', () => {
     it('shows validation alert when required fields are missing', async () => {
         const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
         const route = { params: {} };
-        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
         const { getByText } = render(<CreateEvent navigation={navigation} route={route} />);
 
@@ -395,7 +395,7 @@ describe('CreateEvent – fetchTemplates and applyTemplate', () => {
         });
     });
 
-    it('queries Firestore by the current user\'s ownerId', async () => {
+    it("queries Firestore by the current user's ownerId", async () => {
         const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
         const route = { params: {} };
 
@@ -448,7 +448,7 @@ describe('CreateEvent – fetchTemplates and applyTemplate', () => {
 
     it('shows error alert when getDocs throws', async () => {
         mockGetDocs.mockRejectedValue(new Error('Network error'));
-        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+        const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
         const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
         const route = { params: {} };
@@ -488,9 +488,7 @@ describe('CreateEvent – applyTemplate via route.params', () => {
         };
         const route = { params: { template: templateParam } };
 
-        const { getByDisplayValue } = render(
-            <CreateEvent navigation={navigation} route={route} />,
-        );
+        const { getByDisplayValue } = render(<CreateEvent navigation={navigation} route={route} />);
 
         await waitFor(() => {
             expect(getByDisplayValue('Workshop on AI')).toBeTruthy();


### PR DESCRIPTION
# Description

Adds an Event Template Library to `CreateEventScreen`. Club admins can save any event form as a reusable template and apply saved templates when creating future events, avoiding repetitive form filling.

Fixes #562

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

8 new unit tests added to `app/src/screens/__tests__/CreateEvent.test.js` covering the full template lifecycle.

```bash
cd app
npx jest app/src/screens/__tests__/CreateEvent.test.js --no-coverage
```

- [x] `saveAsTemplate` saves correct fields to Firestore and validates required fields
- [x] `fetchTemplates` scopes results to current user via `ownerId`
- [x] Selecting a template prefills all form fields
- [x] Empty state and error alert render correctly
- [x] Template passed via `route.params` prefills form on mount
- [x] All 9 tests pass (including pre-existing transaction test)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event template support: Users can now save their current event form as a reusable template and apply previously saved templates to quickly prefill forms when creating similar events.

* **Tests**
  * Enhanced test coverage for template creation, retrieval, and application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->