### PR TITLE
feat: add custom attendee push notifications

### DIFF
--- a/app/src/components/EventPushNotificationModal.js
+++ b/app/src/components/EventPushNotificationModal.js
@@ -1,0 +1,272 @@
+import { Ionicons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import {
+    ActivityIndicator,
+    Alert,
+    Modal,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import { sendEventPushNotification } from '../lib/eventPushNotificationService';
+
+export default function EventPushNotificationModal({
+    visible,
+    eventId,
+    eventTitle,
+    theme,
+    onClose,
+}) {
+    const [title, setTitle] = useState('');
+    const [message, setMessage] = useState('');
+    const [sending, setSending] = useState(false);
+
+    const closeModal = () => {
+        if (sending) return;
+        setTitle('');
+        setMessage('');
+        onClose();
+    };
+
+    const showDeliverySummary = result => {
+        if (result.targetedCount === 0) {
+            Alert.alert(
+                'No Reachable Attendees',
+                'Registered attendees do not have valid push notification tokens yet.',
+            );
+            return;
+        }
+
+        const summary = [`Sent to ${result.sentCount} attendee(s).`];
+        if (result.failedCount > 0) {
+            summary.push(`${result.failedCount} delivery attempt(s) failed.`);
+        }
+        if (result.skippedCount > 0) {
+            summary.push(`${result.skippedCount} attendee(s) could not receive push.`);
+        }
+        Alert.alert('Push Update Sent', summary.join('\n'));
+    };
+
+    const handleSend = async () => {
+        if (sending) return;
+
+        const normalizedTitle = title.trim();
+        const normalizedMessage = message.trim();
+
+        if (!normalizedTitle || !normalizedMessage) {
+            Alert.alert('Missing Details', 'Enter both a notification title and message.');
+            return;
+        }
+
+        setSending(true);
+        try {
+            const result = await sendEventPushNotification(
+                eventId,
+                normalizedTitle,
+                normalizedMessage,
+            );
+            showDeliverySummary(result);
+            setTitle('');
+            setMessage('');
+            onClose();
+        } catch (error) {
+            console.error('Push notification failed:', error);
+            Alert.alert('Unable to Send', error.message || 'Failed to send push notification.');
+        } finally {
+            setSending(false);
+        }
+    };
+
+    return (
+        <Modal visible={visible} transparent animationType="slide" onRequestClose={closeModal}>
+            <View style={styles.overlay}>
+                <View style={[styles.content, { backgroundColor: theme.colors.surface }]}>
+                    <View style={styles.header}>
+                        <View style={styles.heading}>
+                            <Ionicons
+                                name="notifications-outline"
+                                size={22}
+                                color={theme.colors.primary}
+                            />
+                            <Text style={[styles.title, { color: theme.colors.text }]}>
+                                Push Update
+                            </Text>
+                        </View>
+                        <TouchableOpacity onPress={closeModal} disabled={sending}>
+                            <Ionicons name="close" size={24} color={theme.colors.textSecondary} />
+                        </TouchableOpacity>
+                    </View>
+
+                    <Text style={[styles.description, { color: theme.colors.textSecondary }]}>
+                        Send an immediate update to registered attendees who enabled push
+                        notifications.
+                    </Text>
+
+                    <View style={styles.labelRow}>
+                        <Text style={[styles.label, { color: theme.colors.textSecondary }]}>
+                            Title
+                        </Text>
+                        <Text
+                            style={[styles.characterCount, { color: theme.colors.textSecondary }]}
+                        >
+                            {title.length}/80
+                        </Text>
+                    </View>
+                    <TextInput
+                        style={[
+                            styles.input,
+                            { color: theme.colors.text, borderColor: theme.colors.border },
+                        ]}
+                        placeholder={`Update for ${eventTitle}`}
+                        placeholderTextColor={theme.colors.textSecondary}
+                        value={title}
+                        onChangeText={setTitle}
+                        maxLength={80}
+                        editable={!sending}
+                    />
+
+                    <View style={styles.labelRow}>
+                        <Text style={[styles.label, { color: theme.colors.textSecondary }]}>
+                            Message
+                        </Text>
+                        <Text
+                            style={[styles.characterCount, { color: theme.colors.textSecondary }]}
+                        >
+                            {message.length}/500
+                        </Text>
+                    </View>
+                    <TextInput
+                        style={[
+                            styles.input,
+                            styles.messageInput,
+                            { color: theme.colors.text, borderColor: theme.colors.border },
+                        ]}
+                        placeholder="Share a venue, schedule, or event update..."
+                        placeholderTextColor={theme.colors.textSecondary}
+                        multiline
+                        value={message}
+                        onChangeText={setMessage}
+                        maxLength={500}
+                        editable={!sending}
+                    />
+
+                    <TouchableOpacity
+                        style={[
+                            styles.sendButton,
+                            { backgroundColor: theme.colors.primary },
+                            sending && styles.disabledButton,
+                        ]}
+                        onPress={handleSend}
+                        disabled={sending}
+                    >
+                        {sending ? (
+                            <ActivityIndicator color="#fff" />
+                        ) : (
+                            <View style={styles.sendButtonContent}>
+                                <Ionicons name="send" size={18} color="#fff" />
+                                <Text style={styles.sendButtonText}>Send Push Update</Text>
+                            </View>
+                        )}
+                    </TouchableOpacity>
+                </View>
+            </View>
+        </Modal>
+    );
+}
+
+EventPushNotificationModal.propTypes = {
+    visible: PropTypes.bool.isRequired,
+    eventId: PropTypes.string.isRequired,
+    eventTitle: PropTypes.string.isRequired,
+    theme: PropTypes.shape({
+        colors: PropTypes.shape({
+            surface: PropTypes.string.isRequired,
+            primary: PropTypes.string.isRequired,
+            text: PropTypes.string.isRequired,
+            textSecondary: PropTypes.string.isRequired,
+            border: PropTypes.string.isRequired,
+        }).isRequired,
+    }).isRequired,
+    onClose: PropTypes.func.isRequired,
+};
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        justifyContent: 'center',
+        padding: 20,
+    },
+    content: {
+        borderRadius: 20,
+        padding: 20,
+        elevation: 5,
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 12,
+    },
+    heading: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: 'bold',
+    },
+    description: {
+        fontSize: 14,
+        lineHeight: 20,
+        marginBottom: 18,
+    },
+    labelRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    label: {
+        fontSize: 14,
+        marginBottom: 8,
+        fontWeight: '600',
+    },
+    characterCount: {
+        fontSize: 12,
+        marginBottom: 8,
+    },
+    input: {
+        borderWidth: 1,
+        borderRadius: 12,
+        padding: 12,
+        marginBottom: 16,
+        fontSize: 16,
+    },
+    messageInput: {
+        height: 120,
+        textAlignVertical: 'top',
+    },
+    sendButton: {
+        padding: 16,
+        borderRadius: 14,
+        alignItems: 'center',
+        marginTop: 10,
+    },
+    disabledButton: {
+        opacity: 0.65,
+    },
+    sendButtonContent: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    sendButtonText: {
+        color: '#fff',
+        fontSize: 16,
+        fontWeight: 'bold',
+    },
+});

--- a/app/src/components/__tests__/EventPushNotificationModal.test.js
+++ b/app/src/components/__tests__/EventPushNotificationModal.test.js
@@ -1,0 +1,104 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import EventPushNotificationModal from '../EventPushNotificationModal';
+import { sendEventPushNotification } from '../../lib/eventPushNotificationService';
+
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const { Text } = require('react-native');
+    const MockIonicons = ({ name }) => React.createElement(Text, null, name);
+    MockIonicons.propTypes = {
+        name: PropTypes.string.isRequired,
+    };
+
+    return {
+        Ionicons: MockIonicons,
+    };
+});
+
+jest.mock('../../lib/eventPushNotificationService', () => ({
+    sendEventPushNotification: jest.fn(),
+}));
+
+const theme = {
+    colors: {
+        surface: '#fff',
+        primary: '#f5a623',
+        text: '#111',
+        textSecondary: '#666',
+        border: '#ddd',
+    },
+};
+
+describe('EventPushNotificationModal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('requires a title and message before sending', () => {
+        const { getByText } = render(
+            <EventPushNotificationModal
+                visible
+                eventId="event-1"
+                eventTitle="Tech Talk"
+                theme={theme}
+                onClose={jest.fn()}
+            />,
+        );
+
+        fireEvent.press(getByText('Send Push Update'));
+
+        expect(Alert.alert).toHaveBeenCalledWith(
+            'Missing Details',
+            'Enter both a notification title and message.',
+        );
+        expect(sendEventPushNotification).not.toHaveBeenCalled();
+    });
+
+    it('sends the update and closes after success', async () => {
+        const onClose = jest.fn();
+        sendEventPushNotification.mockResolvedValueOnce({
+            targetedCount: 2,
+            sentCount: 2,
+            failedCount: 0,
+            skippedCount: 1,
+        });
+
+        const { getByPlaceholderText, getByText } = render(
+            <EventPushNotificationModal
+                visible
+                eventId="event-1"
+                eventTitle="Tech Talk"
+                theme={theme}
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.changeText(getByPlaceholderText('Update for Tech Talk'), 'Room change');
+        fireEvent.changeText(
+            getByPlaceholderText('Share a venue, schedule, or event update...'),
+            'Meet in Hall B.',
+        );
+        fireEvent.press(getByText('Send Push Update'));
+
+        await waitFor(() => {
+            expect(sendEventPushNotification).toHaveBeenCalledWith(
+                'event-1',
+                'Room change',
+                'Meet in Hall B.',
+            );
+            expect(Alert.alert).toHaveBeenCalledWith(
+                'Push Update Sent',
+                'Sent to 2 attendee(s).\n1 attendee(s) could not receive push.',
+            );
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/app/src/lib/__tests__/eventPushNotificationService.test.js
+++ b/app/src/lib/__tests__/eventPushNotificationService.test.js
@@ -1,0 +1,61 @@
+import { httpsCallable } from 'firebase/functions';
+import { sendEventPushNotification } from '../eventPushNotificationService';
+
+jest.mock('firebase/functions', () => ({
+    httpsCallable: jest.fn(),
+}));
+
+jest.mock('../firebaseConfig', () => ({
+    functions: {},
+}));
+
+describe('eventPushNotificationService', () => {
+    let callable;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        callable = jest.fn();
+        httpsCallable.mockReturnValue(callable);
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('sends a trimmed notification payload to the callable function', async () => {
+        const summary = {
+            success: true,
+            participantCount: 3,
+            targetedCount: 2,
+            sentCount: 2,
+            failedCount: 0,
+            skippedCount: 1,
+        };
+        callable.mockResolvedValueOnce({ data: summary });
+
+        const result = await sendEventPushNotification(
+            'event-1',
+            '  Room change  ',
+            '  Meet in Hall B.  ',
+        );
+
+        expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), 'sendEventPushNotification');
+        expect(callable).toHaveBeenCalledWith({
+            eventId: 'event-1',
+            title: 'Room change',
+            message: 'Meet in Hall B.',
+        });
+        expect(result).toEqual(summary);
+    });
+
+    it('rethrows callable errors', async () => {
+        const error = new Error('Permission denied');
+        callable.mockRejectedValueOnce(error);
+
+        await expect(
+            sendEventPushNotification('event-1', 'Update', 'Meet in Hall B.'),
+        ).rejects.toBe(error);
+        expect(console.error).toHaveBeenCalled();
+    });
+});

--- a/app/src/lib/eventPushNotificationService.js
+++ b/app/src/lib/eventPushNotificationService.js
@@ -1,0 +1,19 @@
+import { httpsCallable } from 'firebase/functions';
+import { functions } from './firebaseConfig';
+import logger from './logger';
+
+export const sendEventPushNotification = async (eventId, title, message) => {
+    try {
+        const sendNotification = httpsCallable(functions, 'sendEventPushNotification');
+        const response = await sendNotification({
+            eventId,
+            title: title.trim(),
+            message: message.trim(),
+        });
+
+        return response.data;
+    } catch (error) {
+        logger.error('Failed to send event push notification:', error);
+        throw error;
+    }
+};

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -35,6 +35,7 @@ import { formatEventDate } from '../lib/formatEventDate';
 import participantService from '../lib/participantService';
 import { useTheme } from '../lib/ThemeContext';
 import { sendBulkAnnouncement, sendBulkFeedbackRequest } from '../lib/EmailService';
+import EventPushNotificationModal from '../components/EventPushNotificationModal';
 import PropTypes from 'prop-types';
 import { COLLECTIONS, getEventCheckInsPath, getEventFeedbackPath } from '../lib/firestorePaths';
 import { useAuth } from '../lib/AuthContext';
@@ -64,6 +65,8 @@ export default function AttendanceDashboard({ route, navigation }) {
     const [announcementMessage, setAnnouncementMessage] = useState('');
     const [sending, setSending] = useState(false);
 
+    // Push Notification State
+    const [pushModalVisible, setPushModalVisible] = useState(false);
     // Feedback Request Modal State
     const [feedbackModalVisible, setFeedbackModalVisible] = useState(false);
 
@@ -680,6 +683,24 @@ export default function AttendanceDashboard({ route, navigation }) {
                                 styles.premiumBtn,
                                 { borderColor: theme.colors.primary },
                             ]}
+                            onPress={() => setPushModalVisible(true)}
+                        >
+                            <Ionicons
+                                name="notifications-outline"
+                                size={24}
+                                color={theme.colors.primary}
+                            />
+                            <Text style={[styles.exportBtnText, { color: theme.colors.primary }]}>
+                                Push Update
+                            </Text>
+                        </TouchableOpacity>
+
+                        <TouchableOpacity
+                            style={[
+                                styles.exportBtn,
+                                styles.premiumBtn,
+                                { borderColor: theme.colors.primary },
+                            ]}
                             onPress={() => setAnnouncementModalVisible(true)}
                         >
                             <Ionicons name="megaphone" size={24} color={theme.colors.primary} />
@@ -848,6 +869,14 @@ export default function AttendanceDashboard({ route, navigation }) {
                     </View>
                 </View>
             </Modal>
+
+            <EventPushNotificationModal
+                visible={pushModalVisible}
+                eventId={eventId}
+                eventTitle={eventTitle}
+                theme={theme}
+                onClose={() => setPushModalVisible(false)}
+            />
 
             {/* Feedback Request Modal */}
             <Modal
@@ -1209,8 +1238,8 @@ const styles = StyleSheet.create({
     analyticsBarFill: { height: '100%', borderRadius: 4 },
     exportContainer: { margin: 16, marginTop: 0 },
     exportTitle: { fontSize: 17, fontWeight: '700', marginBottom: 12 },
-    exportButtons: { flexDirection: 'row', gap: 12 },
-    exportBtn: { flex: 1, borderRadius: 14, overflow: 'hidden' },
+    exportButtons: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+    exportBtn: { flexGrow: 1, flexBasis: 140, borderRadius: 14, overflow: 'hidden' },
     premiumBtn: {
         flexDirection: 'row',
         alignItems: 'center',

--- a/cloud-functions/lib/index.js
+++ b/cloud-functions/lib/index.js
@@ -62,6 +62,7 @@ __exportStar(require("./permanentCleanup"), exports);
 __exportStar(require("./clubReputation"), exports);
 __exportStar(require("./onEventDelete"), exports);
 __exportStar(require("./events"), exports);
+__exportStar(require("./sendEventPushNotification"), exports);
 exports.cleanupRateLimits = functions.pubsub.schedule('every 1 hour').onRun(async () => {
     await (0, rateLimiter_1.cleanupOldRateLimits)();
     return null;

--- a/cloud-functions/src/index.ts
+++ b/cloud-functions/src/index.ts
@@ -25,6 +25,7 @@ export * from './permanentCleanup';
 export * from './clubReputation';
 export * from './onEventDelete';
 export * from './events';
+export * from './sendEventPushNotification';
 
 export const cleanupRateLimits = functions.pubsub.schedule('every 1 hour').onRun(async () => {
     await cleanupOldRateLimits();

--- a/cloud-functions/src/sendEventPushNotification.test.ts
+++ b/cloud-functions/src/sendEventPushNotification.test.ts
@@ -145,6 +145,38 @@ describe('sendEventPushNotification', () => {
         expect(result).toMatchObject({ success: true, participantCount: 0 });
     });
 
+    it('records notification history when there are no participants', async () => {
+        const result = await callFunction(
+            {
+                eventId: 'event-1',
+                title: 'Event update',
+                message: 'The venue has changed.',
+            },
+            { uid: 'organizer-1', token: {} },
+        );
+
+        expect(mockSendPushNotifications).toHaveBeenCalledWith([]);
+        expect(mockHistoryAdd).toHaveBeenCalledWith({
+            title: 'Event update',
+            message: 'The venue has changed.',
+            sentBy: 'organizer-1',
+            participantCount: 0,
+            targetedCount: 0,
+            sentCount: 0,
+            failedCount: 0,
+            skippedCount: 0,
+            createdAt: 'server-timestamp',
+        });
+        expect(result).toEqual({
+            success: true,
+            participantCount: 0,
+            targetedCount: 0,
+            sentCount: 0,
+            failedCount: 0,
+            skippedCount: 0,
+        });
+    });
+
     it('rejects deleted events', async () => {
         mockEventGet.mockResolvedValueOnce({
             exists: true,

--- a/cloud-functions/src/sendEventPushNotification.test.ts
+++ b/cloud-functions/src/sendEventPushNotification.test.ts
@@ -1,0 +1,257 @@
+const mockSendPushNotifications = jest.fn();
+const mockIsExpoPushToken = jest.fn();
+const mockHistoryAdd = jest.fn();
+const mockParticipantsGet = jest.fn();
+const mockEventGet = jest.fn();
+const mockGetAll = jest.fn();
+
+jest.mock('./utils/push', () => ({
+    isExpoPushToken: (token: string) => mockIsExpoPushToken(token),
+    sendPushNotifications: (messages: unknown[]) => mockSendPushNotifications(messages),
+}));
+
+jest.mock('firebase-admin', () => ({
+    firestore: Object.assign(
+        jest.fn(() => ({
+            collection: jest.fn(() => ({
+                doc: jest.fn(() => ({
+                    get: mockEventGet,
+                    collection: jest.fn((name: string) => {
+                        if (name === 'participants') {
+                            return { get: mockParticipantsGet };
+                        }
+                        return { add: mockHistoryAdd };
+                    }),
+                })),
+            })),
+            getAll: mockGetAll,
+        })),
+        {
+            FieldValue: {
+                serverTimestamp: jest.fn(() => 'server-timestamp'),
+            },
+        },
+    ),
+}));
+
+jest.mock('firebase-functions', () => ({
+    https: {
+        onCall: jest.fn((handler: unknown) => handler),
+        HttpsError: class HttpsError extends Error {
+            code: string;
+            details?: unknown;
+
+            constructor(code: string, message: string, details?: unknown) {
+                super(message);
+                this.code = code;
+                this.details = details;
+            }
+        },
+    },
+}));
+
+import { sendEventPushNotification } from './sendEventPushNotification';
+
+const callFunction = (data: Record<string, unknown>, auth?: Record<string, unknown>) =>
+    (sendEventPushNotification as unknown as Function)(data, {
+        auth,
+    });
+
+const participantSnapshot = (participants: Array<{ id: string; userId?: string }>) => ({
+    docs: participants.map(participant => ({
+        id: participant.id,
+        data: () => (participant.userId ? { userId: participant.userId } : {}),
+    })),
+});
+
+describe('sendEventPushNotification', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockEventGet.mockResolvedValue({
+            exists: true,
+            data: () => ({ ownerId: 'organizer-1', status: 'active' }),
+        });
+        mockParticipantsGet.mockResolvedValue(participantSnapshot([]));
+        mockGetAll.mockResolvedValue([]);
+        mockSendPushNotifications.mockResolvedValue([]);
+        mockHistoryAdd.mockResolvedValue({ id: 'history-1' });
+        mockIsExpoPushToken.mockImplementation(token => token.startsWith('ExponentPushToken'));
+    });
+
+    it('rejects unauthenticated requests', async () => {
+        await expect(
+            callFunction({
+                eventId: 'event-1',
+                title: 'Update',
+                message: 'Venue changed.',
+            }),
+        ).rejects.toMatchObject({ code: 'unauthenticated' });
+    });
+
+    it('validates title and message lengths', async () => {
+        await expect(
+            callFunction(
+                { eventId: 'event-1', title: ' ', message: 'Venue changed.' },
+                { uid: 'organizer-1', token: {} },
+            ),
+        ).rejects.toMatchObject({ code: 'invalid-argument' });
+
+        await expect(
+            callFunction(
+                { eventId: 'event-1', title: 'Update', message: 'x'.repeat(501) },
+                { uid: 'organizer-1', token: {} },
+            ),
+        ).rejects.toMatchObject({ code: 'invalid-argument' });
+    });
+
+    it('rejects users who do not own the event', async () => {
+        await expect(
+            callFunction(
+                {
+                    eventId: 'event-1',
+                    title: 'Update',
+                    message: 'Venue changed.',
+                },
+                { uid: 'other-user', token: {} },
+            ),
+        ).rejects.toMatchObject({ code: 'permission-denied' });
+    });
+
+    it('rejects requests for events that do not exist', async () => {
+        mockEventGet.mockResolvedValueOnce({ exists: false });
+
+        await expect(
+            callFunction(
+                {
+                    eventId: 'missing-event',
+                    title: 'Update',
+                    message: 'Venue changed.',
+                },
+                { uid: 'organizer-1', token: {} },
+            ),
+        ).rejects.toMatchObject({ code: 'not-found' });
+    });
+
+    it('allows administrators to notify attendees', async () => {
+        const result = await callFunction(
+            {
+                eventId: 'event-1',
+                title: 'Update',
+                message: 'Venue changed.',
+            },
+            { uid: 'admin-1', token: { admin: true } },
+        );
+
+        expect(result).toMatchObject({ success: true, participantCount: 0 });
+    });
+
+    it('rejects deleted events', async () => {
+        mockEventGet.mockResolvedValueOnce({
+            exists: true,
+            data: () => ({ ownerId: 'organizer-1', status: 'deleted' }),
+        });
+
+        await expect(
+            callFunction(
+                {
+                    eventId: 'event-1',
+                    title: 'Update',
+                    message: 'Venue changed.',
+                },
+                { uid: 'organizer-1', token: {} },
+            ),
+        ).rejects.toMatchObject({ code: 'failed-precondition' });
+    });
+
+    it('deduplicates valid push tokens and returns delivery counts', async () => {
+        mockParticipantsGet.mockResolvedValueOnce(
+            participantSnapshot([
+                { id: 'user-1' },
+                { id: 'participant-2', userId: 'user-2' },
+                { id: 'user-3' },
+            ]),
+        );
+        mockGetAll.mockResolvedValueOnce([
+            {
+                exists: true,
+                data: () => ({ pushToken: 'ExponentPushToken[token-1]' }),
+            },
+            {
+                exists: true,
+                data: () => ({ pushToken: 'ExponentPushToken[token-1]' }),
+            },
+            {
+                exists: true,
+                data: () => ({ pushToken: 'invalid-token' }),
+            },
+        ]);
+        mockSendPushNotifications.mockResolvedValueOnce([{ status: 'ok', id: 'ticket-1' }]);
+
+        const result = await callFunction(
+            {
+                eventId: 'event-1',
+                title: ' Room change ',
+                message: ' Meet in Hall B. ',
+            },
+            { uid: 'organizer-1', token: {} },
+        );
+
+        expect(mockSendPushNotifications).toHaveBeenCalledWith([
+            expect.objectContaining({
+                to: 'ExponentPushToken[token-1]',
+                title: 'Room change',
+                body: 'Meet in Hall B.',
+                data: expect.objectContaining({ eventId: 'event-1' }),
+            }),
+        ]);
+        expect(result).toEqual({
+            success: true,
+            participantCount: 3,
+            targetedCount: 1,
+            sentCount: 1,
+            failedCount: 0,
+            skippedCount: 2,
+        });
+        expect(mockHistoryAdd).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sentBy: 'organizer-1',
+                sentCount: 1,
+                skippedCount: 2,
+            }),
+        );
+    });
+
+    it('counts unsuccessful and missing tickets as failed deliveries', async () => {
+        mockParticipantsGet.mockResolvedValueOnce(
+            participantSnapshot([{ id: 'user-1' }, { id: 'user-2' }]),
+        );
+        mockGetAll.mockResolvedValueOnce([
+            {
+                exists: true,
+                data: () => ({ pushToken: 'ExponentPushToken[token-1]' }),
+            },
+            {
+                exists: true,
+                data: () => ({ pushToken: 'ExponentPushToken[token-2]' }),
+            },
+        ]);
+        mockSendPushNotifications.mockResolvedValueOnce([
+            { status: 'error', message: 'DeviceNotRegistered' },
+        ]);
+
+        const result = await callFunction(
+            {
+                eventId: 'event-1',
+                title: 'Update',
+                message: 'Venue changed.',
+            },
+            { uid: 'organizer-1', token: {} },
+        );
+
+        expect(result).toMatchObject({
+            targetedCount: 2,
+            sentCount: 0,
+            failedCount: 2,
+        });
+    });
+});

--- a/cloud-functions/src/sendEventPushNotification.ts
+++ b/cloud-functions/src/sendEventPushNotification.ts
@@ -113,17 +113,6 @@ export const sendEventPushNotification = functions.https.onCall(async (data, con
     const participantsSnapshot = await eventRef.collection('participants').get();
     const participantUserIds = getParticipantUserIds(participantsSnapshot);
 
-    if (participantUserIds.length === 0) {
-        return {
-            success: true,
-            participantCount: 0,
-            targetedCount: 0,
-            sentCount: 0,
-            failedCount: 0,
-            skippedCount: 0,
-        };
-    }
-
     const userDocuments = await getUserDocuments(db, participantUserIds);
     const pushTokens = new Set<string>();
 

--- a/cloud-functions/src/sendEventPushNotification.ts
+++ b/cloud-functions/src/sendEventPushNotification.ts
@@ -1,0 +1,181 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import { ExpoPushMessage, ExpoPushTicket } from 'expo-server-sdk';
+import { isExpoPushToken, sendPushNotifications } from './utils/push';
+
+const MAX_TITLE_LENGTH = 80;
+const MAX_MESSAGE_LENGTH = 500;
+const USER_LOOKUP_BATCH_SIZE = 100;
+
+type PushNotificationPayload = {
+    eventId?: unknown;
+    title?: unknown;
+    message?: unknown;
+};
+
+type ValidatedPayload = {
+    eventId: string;
+    title: string;
+    message: string;
+};
+
+const validatePayload = (data: PushNotificationPayload): ValidatedPayload => {
+    const eventId = typeof data?.eventId === 'string' ? data.eventId.trim() : '';
+    const title = typeof data?.title === 'string' ? data.title.trim() : '';
+    const message = typeof data?.message === 'string' ? data.message.trim() : '';
+
+    if (!eventId) {
+        throw new functions.https.HttpsError('invalid-argument', 'eventId is required.');
+    }
+    if (!title || title.length > MAX_TITLE_LENGTH) {
+        throw new functions.https.HttpsError(
+            'invalid-argument',
+            `Title must be between 1 and ${MAX_TITLE_LENGTH} characters.`,
+        );
+    }
+    if (!message || message.length > MAX_MESSAGE_LENGTH) {
+        throw new functions.https.HttpsError(
+            'invalid-argument',
+            `Message must be between 1 and ${MAX_MESSAGE_LENGTH} characters.`,
+        );
+    }
+
+    return { eventId, title, message };
+};
+
+const getParticipantUserIds = (participantsSnapshot: admin.firestore.QuerySnapshot): string[] => {
+    const userIds = participantsSnapshot.docs
+        .map(participant => {
+            const participantData = participant.data();
+            return typeof participantData.userId === 'string'
+                ? participantData.userId
+                : participant.id;
+        })
+        .filter((userId): userId is string => Boolean(userId));
+
+    return [...new Set(userIds)];
+};
+
+const getUserDocuments = async (
+    db: admin.firestore.Firestore,
+    userIds: string[],
+): Promise<admin.firestore.DocumentSnapshot[]> => {
+    const userDocuments: admin.firestore.DocumentSnapshot[] = [];
+
+    for (let index = 0; index < userIds.length; index += USER_LOOKUP_BATCH_SIZE) {
+        const batch = userIds.slice(index, index + USER_LOOKUP_BATCH_SIZE);
+        const references = batch.map(userId => db.collection('users').doc(userId));
+        const snapshots = await db.getAll(...references);
+        userDocuments.push(...snapshots);
+    }
+
+    return userDocuments;
+};
+
+const countSuccessfulTickets = (tickets: ExpoPushTicket[]) =>
+    tickets.filter(ticket => ticket.status === 'ok').length;
+
+export const sendEventPushNotification = functions.https.onCall(async (data, context) => {
+    if (!context.auth) {
+        throw new functions.https.HttpsError(
+            'unauthenticated',
+            'You must be logged in to send notifications.',
+        );
+    }
+
+    const { eventId, title, message } = validatePayload(data);
+    const db = admin.firestore();
+    const eventRef = db.collection('events').doc(eventId);
+    const eventSnapshot = await eventRef.get();
+
+    if (!eventSnapshot.exists) {
+        throw new functions.https.HttpsError('not-found', 'Event not found.');
+    }
+
+    const eventData = eventSnapshot.data() || {};
+    const isAdmin = context.auth.token.admin === true;
+    const isOwner = eventData.ownerId === context.auth.uid;
+
+    if (!isAdmin && !isOwner) {
+        throw new functions.https.HttpsError(
+            'permission-denied',
+            'Only the event organizer can notify attendees.',
+        );
+    }
+
+    if (eventData.deletedAt != null || eventData.status === 'deleted') {
+        throw new functions.https.HttpsError(
+            'failed-precondition',
+            'Notifications cannot be sent for a deleted event.',
+        );
+    }
+
+    const participantsSnapshot = await eventRef.collection('participants').get();
+    const participantUserIds = getParticipantUserIds(participantsSnapshot);
+
+    if (participantUserIds.length === 0) {
+        return {
+            success: true,
+            participantCount: 0,
+            targetedCount: 0,
+            sentCount: 0,
+            failedCount: 0,
+            skippedCount: 0,
+        };
+    }
+
+    const userDocuments = await getUserDocuments(db, participantUserIds);
+    const pushTokens = new Set<string>();
+
+    userDocuments.forEach(userDocument => {
+        if (!userDocument.exists) return;
+
+        const pushToken = userDocument.data()?.pushToken;
+        if (typeof pushToken === 'string' && isExpoPushToken(pushToken)) {
+            pushTokens.add(pushToken);
+        }
+    });
+
+    const messages: ExpoPushMessage[] = [...pushTokens].map(pushToken => ({
+        to: pushToken,
+        sound: 'default',
+        title,
+        body: message,
+        data: {
+            eventId,
+            url: `/event/${eventId}`,
+            type: 'organizer-update',
+        },
+    }));
+
+    const tickets = await sendPushNotifications(messages);
+    const sentCount = countSuccessfulTickets(tickets);
+    const targetedCount = messages.length;
+    const failedCount = Math.max(targetedCount - sentCount, 0);
+    const skippedCount = Math.max(participantUserIds.length - targetedCount, 0);
+
+    try {
+        await eventRef.collection('notificationHistory').add({
+            title,
+            message,
+            sentBy: context.auth.uid,
+            participantCount: participantUserIds.length,
+            targetedCount,
+            sentCount,
+            failedCount,
+            skippedCount,
+            createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+    } catch (error) {
+        console.error(`Failed to record notification history for event ${eventId}:`, error);
+    }
+
+    return {
+        success: true,
+        participantCount: participantUserIds.length,
+        targetedCount,
+        sentCount,
+        failedCount,
+        skippedCount,
+    };
+});


### PR DESCRIPTION
Adds a custom push notification feature that allows event organizers to send immediate updates to registered attendees.

## Changes

- Added a **Push Update** action to the attendance dashboard.
- Added a notification composer with title and message limits.
- Added loading, validation, and delivery-result feedback.
- Added a Firebase callable function to:
  - verify organizer/admin permissions
  - collect and deduplicate valid Expo push tokens
  - send notifications through Expo
  - record notification history
- Added frontend and backend tests.
- Made communication actions wrap on smaller screens.

## Existing Announcement Feature

The existing **Announce** action sends bulk emails. This PR adds a separate **Push Update** action for immediate mobile notifications.

## Testing

- App: 25 test suites, 138 tests passed
- Cloud function: 8 tests passed
- App and cloud-function lint passed
- Cloud-function TypeScript build passed

## Screenshots

### Push Update action
<img width="400" height="700" alt="custom-push-notifications-dashboard" src="https://github.com/user-attachments/assets/20def125-ff1a-41d3-8c7c-6ec6c62cad83" />

### Notification composer
<img width="400" height="700" alt="custom-push-notifications-composer" src="https://github.com/user-attachments/assets/d0ee1d1a-953c-4993-a100-b8d4a0022421" />

Closes #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event organizers can now send push notifications to registered attendees directly from the Attendance Dashboard.
  * Notifications support customizable titles and messages with character limits and real-time delivery tracking.
  * Send status displays a summary of successful, failed, and skipped notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->