### PR TITLE
feat: Preview Mode for Event Planners

### DIFF
--- a/app/src/components/EventPreview.js
+++ b/app/src/components/EventPreview.js
@@ -1,0 +1,586 @@
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import PropTypes from 'prop-types';
+import React, { useMemo } from 'react';
+import {
+    ImageBackground,
+    Modal,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { formatEventDate, formatEventTime } from '../lib/formatEventDate';
+import { useTheme } from '../lib/ThemeContext';
+
+const DEFAULT_BANNERS = [
+    'https://images.unsplash.com/photo-1540575467063-178a50c2df87?auto=format&fit=crop&w=1000&q=80',
+    'https://images.unsplash.com/photo-1501281668745-f7f57925c3b4?auto=format&fit=crop&w=1000&q=80',
+    'https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1000&q=80',
+    'https://images.unsplash.com/photo-1523240795612-9a054b0db644?auto=format&fit=crop&w=1000&q=80',
+];
+
+export default function EventPreview({ visible, onClose, eventData, organizerName }) {
+    const { theme } = useTheme();
+    const styles = useMemo(() => getStyles(theme), [theme]);
+
+    const bannerUrl = useMemo(() => {
+        if (eventData.imageUri) return eventData.imageUri;
+        return DEFAULT_BANNERS[0];
+    }, [eventData.imageUri]);
+
+    const formattedStart = useMemo(() => {
+        if (!eventData.startDate) return '';
+        try {
+            return `${formatEventDate(eventData.startDate)} at ${formatEventTime(eventData.startDate)}`;
+        } catch {
+            return String(eventData.startDate);
+        }
+    }, [eventData.startDate]);
+
+    const formattedEnd = useMemo(() => {
+        if (!eventData.endDate) return '';
+        try {
+            return `${formatEventDate(eventData.endDate)} at ${formatEventTime(eventData.endDate)}`;
+        } catch {
+            return String(eventData.endDate);
+        }
+    }, [eventData.endDate]);
+
+    const priceLabel = useMemo(() => {
+        if (!eventData.isPaid) return 'Free';
+        const parsedPrice = Number.parseFloat(eventData.price);
+        if (Number.isNaN(parsedPrice) || parsedPrice <= 0) return 'Free';
+        return `\u20B9${parsedPrice}`;
+    }, [eventData.isPaid, eventData.price]);
+
+    return (
+        <Modal
+            visible={visible}
+            animationType="slide"
+            onRequestClose={onClose}
+            presentationStyle="overFullScreen"
+        >
+            <SafeAreaView style={styles.safeContainer} edges={['bottom']}>
+                {/* Floating Preview Badge / Header */}
+                <View style={styles.previewHeaderBanner}>
+                    <Text style={styles.previewHeaderTitle}>Preview Mode</Text>
+                    <Text style={styles.previewHeaderSubtitle}>
+                        This is how your event will look to others
+                    </Text>
+                </View>
+
+                <ScrollView bounces={false} showsVerticalScrollIndicator={false}>
+                    {/* Immersive Header Image */}
+                    <ImageBackground source={{ uri: bannerUrl }} style={styles.headerImage}>
+                        <LinearGradient
+                            colors={['rgba(0,0,0,0.6)', 'transparent', 'rgba(0,0,0,0.8)']}
+                            style={styles.headerGradient}
+                        >
+                            <View style={styles.headerSafe}>
+                                <TouchableOpacity style={styles.backButton} onPress={onClose}>
+                                    <Ionicons name="arrow-back" size={24} color="#fff" />
+                                </TouchableOpacity>
+                            </View>
+                        </LinearGradient>
+                    </ImageBackground>
+
+                    {/* Content Sheet */}
+                    <View style={styles.contentSheet}>
+                        {/* Badges Row */}
+                        <View style={styles.badgeRow}>
+                            <View
+                                style={[
+                                    styles.categoryBadge,
+                                    { backgroundColor: theme.colors.primary + '20' },
+                                ]}
+                            >
+                                <Text
+                                    style={[styles.categoryText, { color: theme.colors.primary }]}
+                                >
+                                    {eventData.category || 'General'}
+                                </Text>
+                            </View>
+
+                            <View
+                                style={[
+                                    styles.priceBadge,
+                                    { backgroundColor: eventData.isPaid ? '#F59E0B' : '#10B981' },
+                                ]}
+                            >
+                                <Ionicons
+                                    name={eventData.isPaid ? 'cash' : 'gift'}
+                                    size={14}
+                                    color="#fff"
+                                />
+                                <Text style={styles.priceText}>{priceLabel}</Text>
+                            </View>
+                        </View>
+
+                        {/* Title */}
+                        <Text style={[styles.eventTitle, { color: theme.colors.text }]}>
+                            {eventData.title || 'Untitled Event'}
+                        </Text>
+
+                        {/* Organizer Profile Summary */}
+                        <View style={styles.hostButton}>
+                            <View
+                                style={[
+                                    styles.hostAvatar,
+                                    { backgroundColor: theme.colors.primary + '20' },
+                                ]}
+                            >
+                                <Text
+                                    style={[styles.hostAvatarText, { color: theme.colors.primary }]}
+                                >
+                                    {(organizerName || 'O').charAt(0).toUpperCase()}
+                                </Text>
+                            </View>
+                            <View>
+                                <Text
+                                    style={[
+                                        styles.hostLabel,
+                                        { color: theme.colors.textSecondary },
+                                    ]}
+                                >
+                                    Hosted by
+                                </Text>
+                                <Text style={[styles.hostName, { color: theme.colors.text }]}>
+                                    {organizerName || 'Club Organizer'}
+                                </Text>
+                            </View>
+                        </View>
+
+                        {/* Details Card */}
+                        <View
+                            style={[
+                                styles.detailsCard,
+                                {
+                                    backgroundColor: theme.colors.surface,
+                                    borderColor: theme.colors.border,
+                                    borderWidth: 1,
+                                },
+                            ]}
+                        >
+                            {/* Date Detail */}
+                            <View style={styles.detailRow}>
+                                <View
+                                    style={[
+                                        styles.detailIconContainer,
+                                        { backgroundColor: theme.colors.primary + '15' },
+                                    ]}
+                                >
+                                    <Ionicons
+                                        name="calendar"
+                                        size={22}
+                                        color={theme.colors.primary}
+                                    />
+                                </View>
+                                <View style={styles.detailContent}>
+                                    <Text
+                                        style={[
+                                            styles.detailLabel,
+                                            { color: theme.colors.textSecondary },
+                                        ]}
+                                    >
+                                        Date & Time
+                                    </Text>
+                                    <Text
+                                        style={[styles.detailValue, { color: theme.colors.text }]}
+                                    >
+                                        {formattedStart || 'Not specified'}
+                                    </Text>
+                                    {formattedEnd && (
+                                        <Text
+                                            style={[
+                                                styles.detailSubValue,
+                                                { color: theme.colors.textSecondary },
+                                            ]}
+                                        >
+                                            Ends: {formattedEnd}
+                                        </Text>
+                                    )}
+                                </View>
+                            </View>
+
+                            <View
+                                style={[
+                                    styles.detailDivider,
+                                    { backgroundColor: theme.colors.border },
+                                ]}
+                            />
+
+                            {/* Location Detail */}
+                            <View style={styles.detailRow}>
+                                <View
+                                    style={[
+                                        styles.detailIconContainer,
+                                        { backgroundColor: theme.colors.primary + '15' },
+                                    ]}
+                                >
+                                    <Ionicons
+                                        name={eventData.eventMode === 'online' ? 'videocam' : 'pin'}
+                                        size={22}
+                                        color={theme.colors.primary}
+                                    />
+                                </View>
+                                <View style={styles.detailContent}>
+                                    <Text
+                                        style={[
+                                            styles.detailLabel,
+                                            { color: theme.colors.textSecondary },
+                                        ]}
+                                    >
+                                        {eventData.eventMode === 'online'
+                                            ? 'Online Event'
+                                            : 'Venue'}
+                                    </Text>
+                                    <Text
+                                        style={[styles.detailValue, { color: theme.colors.text }]}
+                                    >
+                                        {eventData.eventMode === 'online'
+                                            ? eventData.meetLink || 'Google Meet'
+                                            : eventData.location || 'Not specified'}
+                                    </Text>
+                                </View>
+                            </View>
+                        </View>
+
+                        {/* About Section */}
+                        <View style={styles.aboutSection}>
+                            <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
+                                About Event
+                            </Text>
+                            <Text style={[styles.description, { color: theme.colors.text }]}>
+                                {eventData.description || 'No description provided.'}
+                            </Text>
+                        </View>
+
+                        {/* Tags Section */}
+                        {eventData.tags && eventData.tags.length > 0 && (
+                            <View style={styles.aboutSection}>
+                                <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
+                                    Tags
+                                </Text>
+                                <View style={styles.tagsContainer}>
+                                    {eventData.tags.map(tag => (
+                                        <View
+                                            key={tag}
+                                            style={[
+                                                styles.tagChip,
+                                                {
+                                                    backgroundColor: theme.colors.surface,
+                                                    borderColor: theme.colors.border,
+                                                },
+                                            ]}
+                                        >
+                                            <Text
+                                                style={[
+                                                    styles.tagText,
+                                                    { color: theme.colors.textSecondary },
+                                                ]}
+                                            >
+                                                #{tag}
+                                            </Text>
+                                        </View>
+                                    ))}
+                                </View>
+                            </View>
+                        )}
+
+                        {/* Target Audience Section */}
+                        <View style={styles.aboutSection}>
+                            <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
+                                Target Audience
+                            </Text>
+                            <View style={styles.audienceContainer}>
+                                <Text
+                                    style={[
+                                        styles.audienceLabel,
+                                        { color: theme.colors.textSecondary },
+                                    ]}
+                                >
+                                    Branches:{' '}
+                                    <Text style={{ color: theme.colors.text, fontWeight: '600' }}>
+                                        {eventData.targetBranches &&
+                                        eventData.targetBranches.length > 0
+                                            ? eventData.targetBranches.join(', ')
+                                            : 'All'}
+                                    </Text>
+                                </Text>
+                                <Text
+                                    style={[
+                                        styles.audienceLabel,
+                                        { color: theme.colors.textSecondary, marginTop: 4 },
+                                    ]}
+                                >
+                                    Years:{' '}
+                                    <Text style={{ color: theme.colors.text, fontWeight: '600' }}>
+                                        {eventData.targetYears && eventData.targetYears.length > 0
+                                            ? eventData.targetYears
+                                                  .map(y => `${y}st/nd/rd/th Year`)
+                                                  .join(', ')
+                                            : 'All'}
+                                    </Text>
+                                </Text>
+                            </View>
+                        </View>
+
+                        {/* Bottom Buffer */}
+                        <View style={{ height: 100 }} />
+                    </View>
+                </ScrollView>
+
+                {/* Sticky Close Button in Preview */}
+                <View
+                    style={[
+                        styles.fabContainer,
+                        {
+                            backgroundColor: theme.colors.background,
+                            borderTopColor: theme.colors.border,
+                        },
+                    ]}
+                >
+                    <View style={styles.fabSubInfo}>
+                        <Text style={styles.fabLabel}>Status</Text>
+                        <Text style={[styles.fabValue, { color: theme.colors.text }]}>
+                            Draft Preview
+                        </Text>
+                    </View>
+                    <TouchableOpacity style={styles.primaryBtn} onPress={onClose}>
+                        <Text style={styles.primaryBtnText}>Close Preview</Text>
+                    </TouchableOpacity>
+                </View>
+            </SafeAreaView>
+        </Modal>
+    );
+}
+
+EventPreview.propTypes = {
+    visible: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    organizerName: PropTypes.string,
+    eventData: PropTypes.shape({
+        title: PropTypes.string,
+        description: PropTypes.string,
+        tags: PropTypes.arrayOf(PropTypes.string),
+        category: PropTypes.string,
+        location: PropTypes.string,
+        startDate: PropTypes.instanceOf(Date),
+        endDate: PropTypes.instanceOf(Date),
+        eventMode: PropTypes.string,
+        meetLink: PropTypes.string,
+        isPaid: PropTypes.bool,
+        price: PropTypes.string,
+        imageUri: PropTypes.string,
+        targetBranches: PropTypes.arrayOf(PropTypes.string),
+        targetYears: PropTypes.arrayOf(PropTypes.number),
+    }).isRequired,
+};
+
+const getStyles = theme =>
+    StyleSheet.create({
+        safeContainer: {
+            flex: 1,
+            backgroundColor: theme.colors.background,
+        },
+        previewHeaderBanner: {
+            backgroundColor: '#FF6B35',
+            paddingVertical: 10,
+            paddingHorizontal: 20,
+            alignItems: 'center',
+            justifyContent: 'center',
+            ...Platform.select({
+                ios: {
+                    paddingTop: 14,
+                },
+            }),
+        },
+        previewHeaderTitle: {
+            color: '#fff',
+            fontWeight: 'bold',
+            fontSize: 16,
+            textTransform: 'uppercase',
+            letterSpacing: 1,
+        },
+        previewHeaderSubtitle: {
+            color: 'rgba(255,255,255,0.85)',
+            fontSize: 11,
+            marginTop: 2,
+        },
+        headerImage: { height: 350, width: '100%' },
+        headerGradient: { flex: 1, paddingTop: 20, paddingHorizontal: 20 },
+        headerSafe: { flexDirection: 'row', justifyContent: 'space-between' },
+        backButton: {
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        contentSheet: {
+            flex: 1,
+            marginTop: -40,
+            borderTopLeftRadius: 32,
+            borderTopRightRadius: 32,
+            backgroundColor: theme.colors.background,
+            paddingHorizontal: 24,
+            paddingTop: 32,
+        },
+        badgeRow: {
+            flexDirection: 'row',
+            gap: 8,
+            marginBottom: 16,
+        },
+        categoryBadge: {
+            paddingHorizontal: 12,
+            paddingVertical: 6,
+            borderRadius: 20,
+        },
+        categoryText: {
+            fontSize: 12,
+            fontWeight: '600',
+        },
+        priceBadge: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 4,
+            paddingHorizontal: 12,
+            paddingVertical: 6,
+            borderRadius: 20,
+        },
+        priceText: {
+            color: '#fff',
+            fontSize: 12,
+            fontWeight: '700',
+        },
+        eventTitle: {
+            fontSize: 28,
+            fontWeight: '800',
+            marginBottom: 16,
+            lineHeight: 34,
+        },
+        hostButton: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 12,
+            paddingVertical: 12,
+            marginBottom: 20,
+        },
+        hostAvatar: {
+            width: 44,
+            height: 44,
+            borderRadius: 22,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        hostAvatarText: {
+            fontSize: 18,
+            fontWeight: '700',
+        },
+        hostLabel: {
+            fontSize: 12,
+        },
+        hostName: {
+            fontSize: 16,
+            fontWeight: '600',
+        },
+        detailsCard: {
+            borderRadius: 20,
+            padding: 20,
+            marginBottom: 25,
+        },
+        detailRow: {
+            flexDirection: 'row',
+            alignItems: 'flex-start',
+            gap: 16,
+        },
+        detailIconContainer: {
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        detailContent: {
+            flex: 1,
+        },
+        detailLabel: {
+            fontSize: 12,
+            fontWeight: '500',
+            marginBottom: 4,
+        },
+        detailValue: {
+            fontSize: 16,
+            fontWeight: '600',
+            marginBottom: 2,
+        },
+        detailSubValue: {
+            fontSize: 14,
+        },
+        detailDivider: {
+            height: 1,
+            marginVertical: 16,
+        },
+        aboutSection: {
+            marginBottom: 25,
+        },
+        sectionTitle: {
+            fontSize: 18,
+            fontWeight: '700',
+            marginBottom: 12,
+        },
+        description: {
+            fontSize: 15,
+            lineHeight: 24,
+        },
+        tagsContainer: {
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            gap: 8,
+        },
+        tagChip: {
+            paddingHorizontal: 12,
+            paddingVertical: 6,
+            borderRadius: 15,
+            borderWidth: 1,
+        },
+        tagText: {
+            fontSize: 13,
+            fontWeight: '500',
+        },
+        audienceContainer: {
+            padding: 16,
+            borderRadius: 12,
+            backgroundColor: 'rgba(0,0,0,0.02)',
+        },
+        audienceLabel: {
+            fontSize: 14,
+        },
+        fabContainer: {
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            padding: 20,
+            paddingBottom: Platform.OS === 'ios' ? 36 : 24,
+            borderTopWidth: 1,
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+        },
+        fabSubInfo: { justifyContent: 'center' },
+        fabLabel: { fontSize: 12, opacity: 0.6 },
+        fabValue: { fontSize: 16, fontWeight: 'bold' },
+        primaryBtn: {
+            backgroundColor: theme.colors.primary,
+            paddingVertical: 14,
+            paddingHorizontal: 32,
+            borderRadius: 12,
+        },
+        primaryBtnText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
+    });

--- a/app/src/components/EventPreview.js
+++ b/app/src/components/EventPreview.js
@@ -321,7 +321,13 @@ export default function EventPreview({ visible, onClose, eventData, organizerNam
                                     <Text style={{ color: theme.colors.text, fontWeight: '600' }}>
                                         {eventData.targetYears && eventData.targetYears.length > 0
                                             ? eventData.targetYears
-                                                  .map(y => `${y}st/nd/rd/th Year`)
+                                                  .map(y => {
+                                                      if (y === 1) return '1st Year';
+                                                      if (y === 2) return '2nd Year';
+                                                      if (y === 3) return '3rd Year';
+                                                      if (y === 4) return '4th Year';
+                                                      return `${y}th Year`;
+                                                  })
                                                   .join(', ')
                                             : 'All'}
                                     </Text>

--- a/app/src/components/EventPreview.js
+++ b/app/src/components/EventPreview.js
@@ -7,7 +7,6 @@ import {
     Modal,
     Platform,
     ScrollView,
-    StyleSheet,
     Text,
     TouchableOpacity,
     View,
@@ -15,6 +14,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { formatEventDate, formatEventTime } from '../lib/formatEventDate';
 import { useTheme } from '../lib/ThemeContext';
+import { getStyles as getEventDetailStyles } from '../screens/EventDetail';
 
 const DEFAULT_BANNERS = [
     'https://images.unsplash.com/photo-1540575467063-178a50c2df87?auto=format&fit=crop&w=1000&q=80',
@@ -387,8 +387,10 @@ EventPreview.propTypes = {
     }).isRequired,
 };
 
-const getStyles = theme =>
-    StyleSheet.create({
+const getStyles = theme => {
+    const detailStyles = getEventDetailStyles(theme);
+    return {
+        ...detailStyles,
         safeContainer: {
             flex: 1,
             backgroundColor: theme.colors.background,
@@ -417,176 +419,5 @@ const getStyles = theme =>
             fontSize: 11,
             marginTop: 2,
         },
-        headerImage: { height: 350, width: '100%' },
-        headerGradient: { flex: 1, paddingTop: 20, paddingHorizontal: 20 },
-        headerSafe: { flexDirection: 'row', justifyContent: 'space-between' },
-        backButton: {
-            width: 40,
-            height: 40,
-            borderRadius: 20,
-            backgroundColor: 'rgba(0,0,0,0.5)',
-            alignItems: 'center',
-            justifyContent: 'center',
-        },
-        contentSheet: {
-            flex: 1,
-            marginTop: -40,
-            borderTopLeftRadius: 32,
-            borderTopRightRadius: 32,
-            backgroundColor: theme.colors.background,
-            paddingHorizontal: 24,
-            paddingTop: 32,
-        },
-        badgeRow: {
-            flexDirection: 'row',
-            gap: 8,
-            marginBottom: 16,
-        },
-        categoryBadge: {
-            paddingHorizontal: 12,
-            paddingVertical: 6,
-            borderRadius: 20,
-        },
-        categoryText: {
-            fontSize: 12,
-            fontWeight: '600',
-        },
-        priceBadge: {
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: 4,
-            paddingHorizontal: 12,
-            paddingVertical: 6,
-            borderRadius: 20,
-        },
-        priceText: {
-            color: '#fff',
-            fontSize: 12,
-            fontWeight: '700',
-        },
-        eventTitle: {
-            fontSize: 28,
-            fontWeight: '800',
-            marginBottom: 16,
-            lineHeight: 34,
-        },
-        hostButton: {
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: 12,
-            paddingVertical: 12,
-            marginBottom: 20,
-        },
-        hostAvatar: {
-            width: 44,
-            height: 44,
-            borderRadius: 22,
-            alignItems: 'center',
-            justifyContent: 'center',
-        },
-        hostAvatarText: {
-            fontSize: 18,
-            fontWeight: '700',
-        },
-        hostLabel: {
-            fontSize: 12,
-        },
-        hostName: {
-            fontSize: 16,
-            fontWeight: '600',
-        },
-        detailsCard: {
-            borderRadius: 20,
-            padding: 20,
-            marginBottom: 25,
-        },
-        detailRow: {
-            flexDirection: 'row',
-            alignItems: 'flex-start',
-            gap: 16,
-        },
-        detailIconContainer: {
-            width: 48,
-            height: 48,
-            borderRadius: 24,
-            alignItems: 'center',
-            justifyContent: 'center',
-        },
-        detailContent: {
-            flex: 1,
-        },
-        detailLabel: {
-            fontSize: 12,
-            fontWeight: '500',
-            marginBottom: 4,
-        },
-        detailValue: {
-            fontSize: 16,
-            fontWeight: '600',
-            marginBottom: 2,
-        },
-        detailSubValue: {
-            fontSize: 14,
-        },
-        detailDivider: {
-            height: 1,
-            marginVertical: 16,
-        },
-        aboutSection: {
-            marginBottom: 25,
-        },
-        sectionTitle: {
-            fontSize: 18,
-            fontWeight: '700',
-            marginBottom: 12,
-        },
-        description: {
-            fontSize: 15,
-            lineHeight: 24,
-        },
-        tagsContainer: {
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            gap: 8,
-        },
-        tagChip: {
-            paddingHorizontal: 12,
-            paddingVertical: 6,
-            borderRadius: 15,
-            borderWidth: 1,
-        },
-        tagText: {
-            fontSize: 13,
-            fontWeight: '500',
-        },
-        audienceContainer: {
-            padding: 16,
-            borderRadius: 12,
-            backgroundColor: 'rgba(0,0,0,0.02)',
-        },
-        audienceLabel: {
-            fontSize: 14,
-        },
-        fabContainer: {
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            padding: 20,
-            paddingBottom: Platform.OS === 'ios' ? 36 : 24,
-            borderTopWidth: 1,
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-        },
-        fabSubInfo: { justifyContent: 'center' },
-        fabLabel: { fontSize: 12, opacity: 0.6 },
-        fabValue: { fontSize: 16, fontWeight: 'bold' },
-        primaryBtn: {
-            backgroundColor: theme.colors.primary,
-            paddingVertical: 14,
-            paddingHorizontal: 32,
-            borderRadius: 12,
-        },
-        primaryBtnText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
-    });
+    };
+};

--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -39,6 +39,7 @@ import { extractTags } from '../lib/tagExtractor';
 import { predictAttendance } from '../lib/capacityPredictor';
 import { enforceRateLimit } from '../lib/rateLimiter';
 import PropTypes from 'prop-types';
+import EventPreview from '../components/EventPreview';
 
 let MapView = null;
 let Marker = null;
@@ -68,6 +69,7 @@ export default function CreateEvent({ navigation, route }) {
     const [templateLoading, setTemplateLoading] = useState(false);
     const [templateModalVisible, setTemplateModalVisible] = useState(false);
     const [templates, setTemplates] = useState([]);
+    const [showPreview, setShowPreview] = useState(false);
 
     // Form State
     const [title, setTitle] = useState('');
@@ -622,11 +624,25 @@ export default function CreateEvent({ navigation, route }) {
 
     return (
         <ScreenWrapper>
-            <View style={styles.header}>
-                <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-                    <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
+            <View
+                style={[styles.header, { justifyContent: 'space-between', alignItems: 'center' }]}
+            >
+                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                    <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+                        <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
+                    </TouchableOpacity>
+                    <Text style={styles.headerTitle}>
+                        {isEditMode ? 'Edit Event' : 'Create Event'}
+                    </Text>
+                </View>
+                <TouchableOpacity
+                    style={styles.headerPreviewBtn}
+                    onPress={() => setShowPreview(true)}
+                    disabled={loading}
+                    accessibilityLabel="Preview Event"
+                >
+                    <Ionicons name="eye-outline" size={24} color={theme.colors.primary} />
                 </TouchableOpacity>
-                <Text style={styles.headerTitle}>{isEditMode ? 'Edit Event' : 'Create Event'}</Text>
             </View>
 
             <ScrollView
@@ -1177,20 +1193,31 @@ export default function CreateEvent({ navigation, route }) {
                     )}
                 </View>
 
-                <TouchableOpacity
-                    style={[styles.createBtn, { opacity: loading ? 0.7 : 1 }]}
-                    onPress={handleCreate}
-                    disabled={loading}
-                >
-                    {loading ? (
-                        <View style={styles.submitLoadingContent}>
-                            <ActivityIndicator color="#fff" />
+                <View style={styles.buttonRow}>
+                    <TouchableOpacity
+                        style={[styles.previewBtn, loading && styles.disabledControl]}
+                        onPress={() => setShowPreview(true)}
+                        disabled={loading}
+                    >
+                        <Ionicons name="eye-outline" size={20} color={theme.colors.primary} />
+                        <Text style={styles.previewBtnText}>Preview</Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                        style={[styles.createBtn, { flex: 2, opacity: loading ? 0.7 : 1 }]}
+                        onPress={handleCreate}
+                        disabled={loading}
+                    >
+                        {loading ? (
+                            <View style={styles.submitLoadingContent}>
+                                <ActivityIndicator color="#fff" />
+                                <Text style={styles.createBtnText}>{submitLabel}</Text>
+                            </View>
+                        ) : (
                             <Text style={styles.createBtnText}>{submitLabel}</Text>
-                        </View>
-                    ) : (
-                        <Text style={styles.createBtnText}>{submitLabel}</Text>
-                    )}
-                </TouchableOpacity>
+                        )}
+                    </TouchableOpacity>
+                </View>
 
                 <View style={{ height: 100 }} />
             </ScrollView>
@@ -1255,6 +1282,28 @@ export default function CreateEvent({ navigation, route }) {
                     </View>
                 </View>
             </Modal>
+
+            <EventPreview
+                visible={showPreview}
+                onClose={() => setShowPreview(false)}
+                organizerName={user?.displayName || 'Club Admin'}
+                eventData={{
+                    title,
+                    description,
+                    tags: selectedTags,
+                    category,
+                    location,
+                    startDate,
+                    endDate,
+                    eventMode,
+                    meetLink,
+                    isPaid,
+                    price,
+                    imageUri,
+                    targetBranches,
+                    targetYears,
+                }}
+            />
         </ScreenWrapper>
     );
 }
@@ -1526,6 +1575,37 @@ const getStyles = theme =>
             borderStyle: 'dashed',
         },
         formBuilderText: { color: theme.colors.primary, fontWeight: 'bold' },
+        headerPreviewBtn: {
+            padding: 8,
+            borderRadius: 20,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        buttonRow: {
+            flexDirection: 'row',
+            gap: 12,
+            marginTop: 10,
+        },
+        previewBtn: {
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1.5,
+            borderColor: theme.colors.primary,
+            borderRadius: 16,
+            paddingVertical: 14,
+        },
+        previewBtnText: {
+            color: theme.colors.primary,
+            fontSize: 16,
+            fontWeight: 'bold',
+        },
     });
 
 CreateEvent.propTypes = {

--- a/app/src/screens/EventDetail.js
+++ b/app/src/screens/EventDetail.js
@@ -2496,7 +2496,7 @@ export default function EventDetail({ route, navigation }) {
     );
 }
 
-const getStyles = theme =>
+export const getStyles = theme =>
     StyleSheet.create({
         // Header
         headerImage: { height: 350, width: '100%' },

--- a/app/src/screens/__tests__/CreateEvent.test.js
+++ b/app/src/screens/__tests__/CreateEvent.test.js
@@ -112,6 +112,36 @@ jest.mock('../../lib/capacityPredictor', () => ({
     predictAttendance: jest.fn(() => null),
 }));
 
+jest.mock('../../components/EventPreview', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const { Text, TouchableOpacity, View } = require('react-native');
+
+    function MockEventPreview({ visible, onClose, eventData, organizerName }) {
+        if (!visible) return null;
+        return React.createElement(
+            View,
+            { testID: 'mock-event-preview' },
+            React.createElement(Text, null, `Title: ${eventData.title}`),
+            React.createElement(Text, null, `Organizer: ${organizerName}`),
+            React.createElement(
+                TouchableOpacity,
+                { onPress: onClose, testID: 'close-preview-btn' },
+                React.createElement(Text, null, 'Close'),
+            ),
+        );
+    }
+
+    MockEventPreview.propTypes = {
+        visible: PropTypes.bool,
+        onClose: PropTypes.func,
+        eventData: PropTypes.object,
+        organizerName: PropTypes.string,
+    };
+
+    return MockEventPreview;
+});
+
 const mockEnforceRateLimit = jest.fn(async () => {});
 jest.mock('../../lib/rateLimiter', () => ({
     enforceRateLimit: (...args) => mockEnforceRateLimit(...args),
@@ -494,5 +524,48 @@ describe('CreateEvent – applyTemplate via route.params', () => {
             expect(getByDisplayValue('Workshop on AI')).toBeTruthy();
             expect(getByDisplayValue('Intro to machine learning.')).toBeTruthy();
         });
+    });
+});
+
+describe('CreateEvent – Preview Mode', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders preview triggers and opens the preview modal', async () => {
+        const navigation = { goBack: jest.fn(), setOptions: jest.fn(), navigate: jest.fn() };
+        const route = { params: {} };
+
+        const { getByPlaceholderText, getByText, getByLabelText, getByTestId, queryByTestId } =
+            render(<CreateEvent navigation={navigation} route={route} />);
+
+        // Fill some data
+        fireEvent.changeText(
+            getByPlaceholderText('e.g. Annual Tech Symposium'),
+            'Preview Event Title',
+        );
+
+        // Assert modal is not open initially
+        expect(queryByTestId('mock-event-preview')).toBeNull();
+
+        // Tap the header preview eye icon
+        const headerPreviewBtn = getByLabelText('Preview Event');
+        fireEvent.press(headerPreviewBtn);
+
+        // Assert modal is now open with correct title
+        expect(queryByTestId('mock-event-preview')).toBeTruthy();
+        expect(getByText('Title: Preview Event Title')).toBeTruthy();
+        expect(getByText('Organizer: Organizer One')).toBeTruthy();
+
+        // Close it
+        fireEvent.press(getByTestId('close-preview-btn'));
+        expect(queryByTestId('mock-event-preview')).toBeNull();
+
+        // Tap the bottom preview button
+        const bottomPreviewBtn = getByText('Preview');
+        fireEvent.press(bottomPreviewBtn);
+
+        // Assert modal is open again
+        expect(queryByTestId('mock-event-preview')).toBeTruthy();
     });
 });


### PR DESCRIPTION
# Description

This PR implements a **Preview Mode for Event Planners** (Issue #574) allowing organizers to preview how their event details look before submitting the creation or updates.

Fixes #574

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The changes have been verified using both automated Jest unit tests and local eslint/prettier verification:

- [x] Run `npx jest src/screens/__tests__/CreateEvent.test.js` to verify triggering, closing, and data matching of the preview modal component.
- [x] Run all unit tests (`npx jest`) to verify codebase integrity (all 147 tests pass).
- [x] Run `npm run lint` to confirm zero linting errors or warnings.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-screen event preview modal allowing users to review complete event details including banner image, category, pricing, organizer information, date/time, venue or meeting link, description, tags, and target audience before publishing.
  * Preview accessible via header icon or dedicated preview button in the event creation screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->