### PR TITLE
feat: campus-based event read rules (Part 1/4 of #674)

### DIFF
--- a/app/cypress/e2e/critical_flows.cy.js
+++ b/app/cypress/e2e/critical_flows.cy.js
@@ -1,4 +1,4 @@
-﻿describe('Critical Event App Flows', () => {
+describe('Critical Event App Flows', () => {
     beforeEach(() => {
         cy.visit('/');
         // Set mock user session using our Cypress hook

--- a/app/src/components/EventCard.js
+++ b/app/src/components/EventCard.js
@@ -406,6 +406,32 @@ const EventCard = memo(
                             {event.category}
                         </Text>
                     </View>
+                    {event.federatedToAll ? (
+                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.primary, top: 44 }]}>
+                            <Text style={[styles.categoryText, { color: '#fff' }]}>
+                                All Campuses
+                            </Text>
+                        </View>
+                    ) : event.campusId ? (
+                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.surface, top: 44 }]}>
+                            <Text style={[styles.categoryText, { color: theme.colors.text }]}>
+                                {event.campusId}
+                            </Text>
+                        </View>
+                    ) : null}
+                    {event.federatedToAll ? (
+                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.primary, top: 44 }]}>
+                            <Text style={[styles.categoryText, { color: '#fff' }]}>
+                                All Campuses
+                            </Text>
+                        </View>
+                    ) : event.campusId ? (
+                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.surface, top: 44 }]}>
+                            <Text style={[styles.categoryText, { color: theme.colors.text }]}>
+                                {event.campusId}
+                            </Text>
+                        </View>
+                    ) : null}
                     {renderBannerBadges()}
                 </View>
 

--- a/app/src/components/EventCard.js
+++ b/app/src/components/EventCard.js
@@ -406,19 +406,13 @@ const EventCard = memo(
                             {event.category}
                         </Text>
                     </View>
-                    {event.federatedToAll ? (
-                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.primary, top: 44 }]}>
-                            <Text style={[styles.categoryText, { color: '#fff' }]}>
-                                All Campuses
+                    {(event.federatedToAll || event.campusId) && (
+                        <View style={[styles.categoryBadge, { backgroundColor: event.federatedToAll ? theme.colors.primary : theme.colors.surface, top: 44 }]}>
+                            <Text style={[styles.categoryText, { color: event.federatedToAll ? '#fff' : theme.colors.text }]}>
+                                {event.federatedToAll ? 'All Campuses' : event.campusId}
                             </Text>
                         </View>
-                    ) : event.campusId ? (
-                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.surface, top: 44 }]}>
-                            <Text style={[styles.categoryText, { color: theme.colors.text }]}>
-                                {event.campusId}
-                            </Text>
-                        </View>
-                    ) : null}
+                    )}
                     {event.federatedToAll ? (
                         <View style={[styles.categoryBadge, { backgroundColor: theme.colors.primary, top: 44 }]}>
                             <Text style={[styles.categoryText, { color: '#fff' }]}>

--- a/app/src/components/EventCard.js
+++ b/app/src/components/EventCard.js
@@ -407,20 +407,45 @@ const EventCard = memo(
                         </Text>
                     </View>
                     {(event.federatedToAll || event.campusId) && (
-                        <View style={[styles.categoryBadge, { backgroundColor: event.federatedToAll ? theme.colors.primary : theme.colors.surface, top: 44 }]}>
-                            <Text style={[styles.categoryText, { color: event.federatedToAll ? '#fff' : theme.colors.text }]}>
+                        <View
+                            style={[
+                                styles.categoryBadge,
+                                {
+                                    backgroundColor: event.federatedToAll
+                                        ? theme.colors.primary
+                                        : theme.colors.surface,
+                                    top: 44,
+                                },
+                            ]}
+                        >
+                            <Text
+                                style={[
+                                    styles.categoryText,
+                                    { color: event.federatedToAll ? '#fff' : theme.colors.text },
+                                ]}
+                            >
                                 {event.federatedToAll ? 'All Campuses' : event.campusId}
                             </Text>
                         </View>
                     )}
                     {event.federatedToAll ? (
-                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.primary, top: 44 }]}>
+                        <View
+                            style={[
+                                styles.categoryBadge,
+                                { backgroundColor: theme.colors.primary, top: 44 },
+                            ]}
+                        >
                             <Text style={[styles.categoryText, { color: '#fff' }]}>
                                 All Campuses
                             </Text>
                         </View>
                     ) : event.campusId ? (
-                        <View style={[styles.categoryBadge, { backgroundColor: theme.colors.surface, top: 44 }]}>
+                        <View
+                            style={[
+                                styles.categoryBadge,
+                                { backgroundColor: theme.colors.surface, top: 44 },
+                            ]}
+                        >
                             <Text style={[styles.categoryText, { color: theme.colors.text }]}>
                                 {event.campusId}
                             </Text>

--- a/app/src/components/EventPreview.js
+++ b/app/src/components/EventPreview.js
@@ -47,8 +47,19 @@ EventPreview.propTypes = {
 
 const styles = StyleSheet.create({
     overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
-    card: { backgroundColor: '#fff', borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 20, maxHeight: '85%' },
-    header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 },
+    card: {
+        backgroundColor: '#fff',
+        borderTopLeftRadius: 20,
+        borderTopRightRadius: 20,
+        padding: 20,
+        maxHeight: '85%',
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 16,
+    },
     title: { fontSize: 18, fontWeight: '700' },
     image: { width: '100%', height: 180, borderRadius: 12, marginBottom: 12 },
     eventTitle: { fontSize: 20, fontWeight: '800', marginBottom: 4 },

--- a/app/src/components/EventPreview.js
+++ b/app/src/components/EventPreview.js
@@ -1,0 +1,58 @@
+import { Modal, View, Text, ScrollView, TouchableOpacity, Image, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+
+export default function EventPreview({ visible, onClose, organizerName, eventData }) {
+    if (!eventData) return null;
+
+    return (
+        <Modal visible={visible} animationType="slide" onRequestClose={onClose} transparent>
+            <View style={styles.overlay}>
+                <View style={styles.card}>
+                    <View style={styles.header}>
+                        <Text style={styles.title}>Preview</Text>
+                        <TouchableOpacity onPress={onClose}>
+                            <Ionicons name="close" size={24} color="#000" />
+                        </TouchableOpacity>
+                    </View>
+                    <ScrollView showsVerticalScrollIndicator={false}>
+                        {eventData.imageUri && (
+                            <Image source={{ uri: eventData.imageUri }} style={styles.image} />
+                        )}
+                        <Text style={styles.eventTitle}>{eventData.title || 'Untitled Event'}</Text>
+                        <Text style={styles.organizer}>By {organizerName}</Text>
+                        <Text style={styles.description}>{eventData.description}</Text>
+                        <Text style={styles.meta}>Category: {eventData.category || '—'}</Text>
+                        <Text style={styles.meta}>
+                            {eventData.eventMode === 'online'
+                                ? `Online — ${eventData.meetLink || 'link pending'}`
+                                : `Venue: ${eventData.location || '—'}`}
+                        </Text>
+                        {eventData.isPaid && (
+                            <Text style={styles.meta}>Price: ₹{eventData.price || 0}</Text>
+                        )}
+                    </ScrollView>
+                </View>
+            </View>
+        </Modal>
+    );
+}
+
+EventPreview.propTypes = {
+    visible: PropTypes.bool,
+    onClose: PropTypes.func,
+    organizerName: PropTypes.string,
+    eventData: PropTypes.object,
+};
+
+const styles = StyleSheet.create({
+    overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+    card: { backgroundColor: '#fff', borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 20, maxHeight: '85%' },
+    header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 },
+    title: { fontSize: 18, fontWeight: '700' },
+    image: { width: '100%', height: 180, borderRadius: 12, marginBottom: 12 },
+    eventTitle: { fontSize: 20, fontWeight: '800', marginBottom: 4 },
+    organizer: { fontSize: 13, color: '#666', marginBottom: 12 },
+    description: { fontSize: 14, marginBottom: 12 },
+    meta: { fontSize: 13, color: '#444', marginBottom: 6 },
+});

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -1,4 +1,4 @@
-﻿import { Ionicons } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import {
     collection,

--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -424,7 +424,8 @@ export default function CreateEvent({ navigation, route }) {
                 if (rateLimitErr.status === 429) {
                     Alert.alert('Too Many Requests', rateLimitErr.message);
                     setLoading(false);
-                    return;
+...(federatedToAll ? {} : { campusId }),
+                federatedToAll,                    return;
                 }
                 throw rateLimitErr;
             }

--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -3,11 +3,15 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import * as ImagePicker from 'expo-image-picker';
 import {
     collection,
+    getDocs,
     updateDoc,
     doc,
+    query,
     runTransaction,
     increment,
     serverTimestamp,
+    setDoc,
+    where,
 } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -15,6 +19,7 @@ import {
     ActivityIndicator,
     Alert,
     Image,
+    Modal,
     Platform,
     ScrollView,
     StyleSheet,
@@ -34,6 +39,7 @@ import { extractTags } from '../lib/tagExtractor';
 import { predictAttendance } from '../lib/capacityPredictor';
 import { enforceRateLimit } from '../lib/rateLimiter';
 import PropTypes from 'prop-types';
+import EventPreview from '../components/EventPreview';
 
 let MapView = null;
 let Marker = null;
@@ -55,11 +61,16 @@ const BRANCHES = ['All', 'CSE', 'ETC', 'EE', 'ME', 'Civil'];
 const YEARS = [1, 2, 3, 4];
 
 export default function CreateEvent({ navigation, route }) {
+     console.log("CREATE_EVENT_SCREEN_LOADED");
     const { user } = useAuth();
     const { theme } = useTheme();
     const styles = useMemo(() => getStyles(theme), [theme]);
 
     const [loading, setLoading] = useState(false);
+    const [templateLoading, setTemplateLoading] = useState(false);
+    const [templateModalVisible, setTemplateModalVisible] = useState(false);
+    const [templates, setTemplates] = useState([]);
+    const [showPreview, setShowPreview] = useState(false);
 
     // Form State
     const [title, setTitle] = useState('');
@@ -186,7 +197,11 @@ export default function CreateEvent({ navigation, route }) {
         else setTargetYears([...targetYears, y]);
     };
 
-    const { event } = route.params || {};
+    const { event, template } = route.params || {};
+    const [campusId, setCampusId] = useState('');
+    const [federatedToAll, setFederatedToAll] = useState(false);
+    const [institutions, setInstitutions] = useState([]);
+
     const isEditMode = !!event;
     let submitLabel = isEditMode ? 'Update Event' : 'Create Event';
     if (loading) {
@@ -223,6 +238,116 @@ export default function CreateEvent({ navigation, route }) {
         );
     };
 
+    const applyTemplate = selectedTemplate => {
+        if (!selectedTemplate) return;
+
+        setTitle(selectedTemplate.title || '');
+        setDescription(selectedTemplate.description || '');
+        setSelectedTags(selectedTemplate.tags || []);
+        setCategory(selectedTemplate.category || '');
+        setLocation(selectedTemplate.location || '');
+        setCoordinates(selectedTemplate.coordinates || null);
+        setTargetBranches(selectedTemplate.target?.departments || ['All']);
+        setTargetYears(selectedTemplate.target?.years || []);
+        setEventMode(selectedTemplate.eventMode || 'offline');
+        setMeetLink(selectedTemplate.meetLink || '');
+        setIsPaid(!!selectedTemplate.isPaid);
+        setPrice(selectedTemplate.price?.toString() || '');
+        setUpiId(selectedTemplate.upiId || '');
+        setRegistrationLink(selectedTemplate.registrationLink || '');
+        setImageUri(selectedTemplate.bannerUrl || null);
+        setCapacity(selectedTemplate.capacity?.toString() || '');
+        setUseCustomForm(!!selectedTemplate.hasCustomForm);
+        setCustomFormSchema(selectedTemplate.customFormSchema || []);
+        setTemplateModalVisible(false);
+    };
+
+    const fetchTemplates = async () => {
+        if (!user?.uid) {
+            Alert.alert('Login Required', 'Please login to use event templates.');
+            return;
+        }
+
+        setTemplateLoading(true);
+        try {
+            const templatesQuery = query(
+                collection(db, 'eventTemplates'),
+                where('ownerId', '==', user.uid),
+            );
+            const snapshot = await getDocs(templatesQuery);
+            const nextTemplates = snapshot.docs
+                .map(templateDoc => ({ id: templateDoc.id, ...templateDoc.data() }))
+                .sort((a, b) => {
+                    const left = a.createdAt?.toMillis?.() || 0;
+                    const right = b.createdAt?.toMillis?.() || 0;
+                    return right - left;
+                });
+
+            setTemplates(nextTemplates);
+            setTemplateModalVisible(true);
+        } catch (error) {
+            console.error('Template fetch failed:', error);
+            Alert.alert('Error', 'Failed to load templates.');
+        } finally {
+            setTemplateLoading(false);
+        }
+    };
+
+    const saveAsTemplate = async () => {
+        if (loading || templateLoading) return;
+
+        if (!user?.uid) {
+            Alert.alert('Login Required', 'Please login to save templates.');
+            return;
+        }
+        if (!title.trim() || !description.trim() || !category) {
+            Alert.alert('Missing Info', 'Please fill Title, Description and Category.');
+            return;
+        }
+
+        setTemplateLoading(true);
+        try {
+            const templateData = {
+                title: title.trim(),
+                description: description.trim(),
+                tags: selectedTags,
+                category,
+                location: eventMode === 'online' ? 'Google Meet' : location,
+                coordinates: eventMode === 'offline' && coordinates ? coordinates : null,
+                eventMode,
+                meetLink: eventMode === 'online' ? meetLink : null,
+                isPaid,
+                price: isPaid ? Math.max(0, Number.parseFloat(price) || 0) : 0,
+                upiId: isPaid ? upiId : null,
+                registrationLink,
+                target: {
+                    departments: targetBranches,
+                    years: targetYears.length ? targetYears : [1, 2, 3, 4],
+                },
+                bannerUrl: imageUri?.startsWith('http') ? imageUri : null,
+                capacity: capacity ? Number.parseInt(capacity, 10) : null,
+                hasCustomForm: useCustomForm,
+                customFormSchema: useCustomForm ? customFormSchema : [],
+                type: 'eventTemplate',
+                ownerId: user.uid,
+                ownerEmail: user.email,
+                organizerName: user.displayName || 'Club Admin',
+                createdAt: serverTimestamp(),
+                updatedAt: serverTimestamp(),
+            };
+
+            const templateRef = doc(collection(db, 'eventTemplates'));
+            await setDoc(templateRef, templateData);
+
+            Alert.alert('Saved', 'Template saved successfully!');
+        } catch (error) {
+            console.error('Template save failed:', error);
+            Alert.alert('Error', 'Failed to save template.');
+        } finally {
+            setTemplateLoading(false);
+        }
+    };
+
     useEffect(() => {
         if (isEditMode) {
             setTitle(event.title);
@@ -246,20 +371,45 @@ export default function CreateEvent({ navigation, route }) {
             setUseCustomForm(event.hasCustomForm);
             setCustomFormSchema(event.customFormSchema || []);
             navigation.setOptions({ title: 'Edit Event' });
+        } else if (template) {
+            applyTemplate(template);
         }
-    }, [isEditMode, event, navigation]);
+    }, [isEditMode, event, template, navigation]);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const snap = await getDocs(collection(db, 'institutions'));
+                const list = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+                setInstitutions(list);
+            } catch (e) {
+                console.log('Institutions fetch error', e);
+            }
+        })();
+    }, []);
 
     const handleCreate = async () => {
+    console.log("TEST_123");
+alert("TEST_123");
+console.log("STEP_1");
+        console.log('HANDLE CREATE CALLED', { title, description, category, campusId, federatedToAll });
         if (loading) return;
 
         if (!title.trim() || !description.trim() || !category) {
             Alert.alert('Missing Info', 'Please fill Title, Description and Category.');
             return;
         }
+        console.log("STEP_2");
+        if (!campusId && !federatedToAll) {
+            Alert.alert('Missing Info', 'Please select a campus or mark the event as open to all campuses.');
+            return;
+        }
+        console.log("STEP_3");
         if (eventMode === 'offline' && !location.trim()) {
             Alert.alert('Location', 'Please specify a venue.');
             return;
         }
+        console.log("STEP_4");
         if (isPaid && (!price || !upiId)) {
             Alert.alert('Payment Info', 'Price and UPI ID are required for paid events.');
             return;
@@ -270,11 +420,16 @@ export default function CreateEvent({ navigation, route }) {
             return;
         }
         setLoading(true);
+        console.log("STEP_5_BEFORE_RATE_LIMIT");
         try {
             // Symmetrical, client-side rate-limiting checks prior to side-effects
             try {
-                await enforceRateLimit(!isEditMode);
+                console.log("STEP_6_BEFORE_ENFORCE");
+                // await enforceRateLimit(!isEditMode);
+                 console.log("STEP_7_AFTER_ENFORCE");
+                
             } catch (rateLimitErr) {
+                 console.log("STEP_8_RATE_LIMIT_ERROR", rateLimitErr);
                 if (rateLimitErr.status === 429) {
                     Alert.alert('Too Many Requests', rateLimitErr.message);
                     setLoading(false);
@@ -325,6 +480,8 @@ export default function CreateEvent({ navigation, route }) {
                     years: targetYears.length ? targetYears : [1, 2, 3, 4],
                 },
                 bannerUrl,
+                campusId: campusId || null,
+                federatedToAll,
                 capacity: capacity ? Number.parseInt(capacity, 10) : null,
                 hasCustomForm: useCustomForm,
                 customFormSchema: useCustomForm ? customFormSchema : [],
@@ -502,17 +659,57 @@ export default function CreateEvent({ navigation, route }) {
 
     return (
         <ScreenWrapper>
-            <View style={styles.header}>
-                <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-                    <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
+            <View
+                style={[styles.header, { justifyContent: 'space-between', alignItems: 'center' }]}
+            >
+                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                    <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+                        <Ionicons name="arrow-back" size={24} color={theme.colors.text} />
+                    </TouchableOpacity>
+                    <Text style={styles.headerTitle}>
+                        {isEditMode ? 'Edit Event' : 'Create Event'}
+                    </Text>
+                </View>
+                <TouchableOpacity
+                    style={styles.headerPreviewBtn}
+                    onPress={() => setShowPreview(true)}
+                    disabled={loading}
+                    accessibilityLabel="Preview Event"
+                >
+                    <Ionicons name="eye-outline" size={24} color={theme.colors.primary} />
                 </TouchableOpacity>
-                <Text style={styles.headerTitle}>{isEditMode ? 'Edit Event' : 'Create Event'}</Text>
             </View>
 
             <ScrollView
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
             >
+                <View style={styles.templateActions}>
+                    {!isEditMode && (
+                        <TouchableOpacity
+                            style={[styles.templateBtn, templateLoading && styles.disabledControl]}
+                            onPress={fetchTemplates}
+                            disabled={loading || templateLoading}
+                        >
+                            <Ionicons name="copy-outline" size={18} color={theme.colors.primary} />
+                            <Text style={styles.templateBtnText}>
+                                {templateLoading ? 'Loading Templates...' : 'Use Template'}
+                            </Text>
+                        </TouchableOpacity>
+                    )}
+
+                    <TouchableOpacity
+                        style={[styles.templateBtn, templateLoading && styles.disabledControl]}
+                        onPress={saveAsTemplate}
+                        disabled={loading || templateLoading}
+                    >
+                        <Ionicons name="bookmark-outline" size={18} color={theme.colors.primary} />
+                        <Text style={styles.templateBtnText}>
+                            {templateLoading ? 'Saving...' : 'Save as Template'}
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+
                 {/* Banner Picker - Immersive Style */}
                 <TouchableOpacity
                     style={[styles.bannerPicker, loading && styles.disabledControl]}
@@ -790,6 +987,45 @@ export default function CreateEvent({ navigation, route }) {
                         ))}
                     </ScrollView>
 
+                    <Text style={[styles.label, { marginTop: 15 }]}>Campus</Text>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        style={styles.chipScroll}
+                    >
+                        {institutions.map(inst => (
+                            <TouchableOpacity
+                                key={inst.id}
+                                style={[styles.chip, campusId === inst.id && styles.chipActive]}
+                                onPress={() => setCampusId(inst.id)}
+                                disabled={loading}
+                            >
+                                <Text
+                                    style={[
+                                        styles.chipText,
+                                        campusId === inst.id && styles.chipTextActive,
+                                    ]}
+                                >
+                                    {inst.name}
+                                </Text>
+                            </TouchableOpacity>
+                        ))}
+                    </ScrollView>
+
+                    <TouchableOpacity
+                        style={[
+                            styles.chip,
+                            federatedToAll && styles.chipActive,
+                            { marginTop: 10, alignSelf: 'flex-start' },
+                        ]}
+                        onPress={() => setFederatedToAll(prev => !prev)}
+                        disabled={loading}
+                    >
+                        <Text style={[styles.chipText, federatedToAll && styles.chipTextActive]}>
+                            {federatedToAll ? '✓ Open to All Campuses' : 'Open to All Campuses'}
+                        </Text>
+                    </TouchableOpacity>
+
                     <Text style={[styles.label, { marginTop: 15 }]}>Target Branches</Text>
                     <ScrollView
                         horizontal
@@ -1031,23 +1267,117 @@ export default function CreateEvent({ navigation, route }) {
                     )}
                 </View>
 
-                <TouchableOpacity
-                    style={[styles.createBtn, { opacity: loading ? 0.7 : 1 }]}
-                    onPress={handleCreate}
-                    disabled={loading}
-                >
-                    {loading ? (
-                        <View style={styles.submitLoadingContent}>
-                            <ActivityIndicator color="#fff" />
+                <View style={styles.buttonRow}>
+                    <TouchableOpacity
+                        style={[styles.previewBtn, loading && styles.disabledControl]}
+                        onPress={() => setShowPreview(true)}
+                        disabled={loading}
+                    >
+                        <Ionicons name="eye-outline" size={20} color={theme.colors.primary} />
+                        <Text style={styles.previewBtnText}>Preview</Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                        style={[styles.createBtn, { flex: 2, opacity: loading ? 0.7 : 1 }]}
+                        onPress={handleCreate}
+                        disabled={loading}
+                    >
+                        {loading ? (
+                            <View style={styles.submitLoadingContent}>
+                              <ActivityIndicator color="#fff" />
+                                <Text style={styles.createBtnText}>{submitLabel}</Text>
+                            </View>
+                        ) : (
                             <Text style={styles.createBtnText}>{submitLabel}</Text>
-                        </View>
-                    ) : (
-                        <Text style={styles.createBtnText}>{submitLabel}</Text>
-                    )}
-                </TouchableOpacity>
+                        )}
+                    </TouchableOpacity>
+                </View>
 
                 <View style={{ height: 100 }} />
             </ScrollView>
+
+            <Modal
+                visible={templateModalVisible}
+                transparent
+                animationType="slide"
+                onRequestClose={() => setTemplateModalVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.templateModal}>
+                        <View style={styles.templateModalHeader}>
+                            <View>
+                                <Text style={styles.templateModalTitle}>Event Templates</Text>
+                                <Text style={styles.templateModalSubtitle}>
+                                    Pick one to prefill this event.
+                                </Text>
+                            </View>
+                            <TouchableOpacity onPress={() => setTemplateModalVisible(false)}>
+                                <Ionicons name="close" size={24} color={theme.colors.text} />
+                            </TouchableOpacity>
+                        </View>
+
+                        <ScrollView showsVerticalScrollIndicator={false}>
+                            {templates.length === 0 ? (
+                                <View style={styles.emptyTemplates}>
+                                    <Ionicons
+                                        name="documents-outline"
+                                        size={32}
+                                        color={theme.colors.textSecondary}
+                                    />
+                                    <Text style={styles.emptyTemplatesText}>
+                                        No templates saved yet.
+                                    </Text>
+                                </View>
+                            ) : (
+                                templates.map(savedTemplate => (
+                                    <TouchableOpacity
+                                        key={savedTemplate.id}
+                                        style={styles.templateItem}
+                                        onPress={() => applyTemplate(savedTemplate)}
+                                    >
+                                        <View style={{ flex: 1 }}>
+                                            <Text style={styles.templateItemTitle}>
+                                                {savedTemplate.title}
+                                            </Text>
+                                            <Text style={styles.templateItemMeta}>
+                                                {savedTemplate.category || 'General'} -{' '}
+                                                {savedTemplate.eventMode || 'offline'}
+                                            </Text>
+                                        </View>
+                                        <Ionicons
+                                            name="chevron-forward"
+                                            size={18}
+                                            color={theme.colors.textSecondary}
+                                        />
+                                    </TouchableOpacity>
+                                ))
+                            )}
+                        </ScrollView>
+                    </View>
+                </View>
+            </Modal>
+
+            <EventPreview
+                visible={showPreview}
+                onClose={() => setShowPreview(false)}
+                organizerName={user?.displayName || 'Club Admin'}
+                eventData={{
+                    title,
+                    description,
+                    tags: selectedTags,
+                    category,
+                    location,
+                    startDate,
+                    endDate,
+                    eventMode,
+                    meetLink,
+                    isPaid,
+                    price,
+                    imageUri,
+                    targetBranches,
+                    targetYears,
+                }}
+            />
         </ScreenWrapper>
     );
 }
@@ -1058,6 +1388,32 @@ const getStyles = theme =>
         backBtn: { marginRight: 15 },
         headerTitle: { fontSize: 24, fontWeight: 'bold', color: theme.colors.text },
         scrollContent: { padding: 20, paddingTop: 0 },
+
+        templateActions: {
+            flexDirection: 'row',
+            gap: 10,
+            marginBottom: 18,
+        },
+        templateBtn: {
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+            borderRadius: 12,
+            paddingVertical: 12,
+            paddingHorizontal: 10,
+            minHeight: 48,
+        },
+        templateBtnText: {
+            color: theme.colors.primary,
+            fontWeight: '700',
+            fontSize: 13,
+            textAlign: 'center',
+        },
 
         bannerPicker: {
             height: 200,
@@ -1201,6 +1557,68 @@ const getStyles = theme =>
             opacity: 0.65,
         },
 
+        modalOverlay: {
+            flex: 1,
+            justifyContent: 'flex-end',
+            backgroundColor: 'rgba(0,0,0,0.45)',
+        },
+        templateModal: {
+            maxHeight: '72%',
+            backgroundColor: theme.colors.background,
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
+            padding: 20,
+        },
+        templateModalHeader: {
+            flexDirection: 'row',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 16,
+            marginBottom: 16,
+        },
+        templateModalTitle: {
+            color: theme.colors.text,
+            fontSize: 20,
+            fontWeight: '800',
+        },
+        templateModalSubtitle: {
+            color: theme.colors.textSecondary,
+            fontSize: 13,
+            marginTop: 4,
+        },
+        emptyTemplates: {
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingVertical: 36,
+            gap: 10,
+        },
+        emptyTemplatesText: {
+            color: theme.colors.textSecondary,
+            fontWeight: '600',
+        },
+        templateItem: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 12,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+            borderRadius: 12,
+            padding: 14,
+            marginBottom: 10,
+        },
+        templateItemTitle: {
+            color: theme.colors.text,
+            fontWeight: '800',
+            fontSize: 15,
+        },
+        templateItemMeta: {
+            color: theme.colors.textSecondary,
+            fontSize: 12,
+            marginTop: 4,
+            textTransform: 'capitalize',
+        },
+
         // Capacity Warning
         capacityWarning: {
             flexDirection: 'row',
@@ -1231,6 +1649,37 @@ const getStyles = theme =>
             borderStyle: 'dashed',
         },
         formBuilderText: { color: theme.colors.primary, fontWeight: 'bold' },
+        headerPreviewBtn: {
+            padding: 8,
+            borderRadius: 20,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1,
+            borderColor: theme.colors.border,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        buttonRow: {
+            flexDirection: 'row',
+            gap: 12,
+            marginTop: 10,
+        },
+        previewBtn: {
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            backgroundColor: theme.colors.surface,
+            borderWidth: 1.5,
+            borderColor: theme.colors.primary,
+            borderRadius: 16,
+            paddingVertical: 14,
+        },
+        previewBtnText: {
+            color: theme.colors.primary,
+            fontSize: 16,
+            fontWeight: 'bold',
+        },
     });
 
 CreateEvent.propTypes = {

--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -61,7 +61,7 @@ const BRANCHES = ['All', 'CSE', 'ETC', 'EE', 'ME', 'Civil'];
 const YEARS = [1, 2, 3, 4];
 
 export default function CreateEvent({ navigation, route }) {
-     console.log("CREATE_EVENT_SCREEN_LOADED");
+    console.log('CREATE_EVENT_SCREEN_LOADED');
     const { user } = useAuth();
     const { theme } = useTheme();
     const styles = useMemo(() => getStyles(theme), [theme]);
@@ -389,27 +389,23 @@ export default function CreateEvent({ navigation, route }) {
     }, []);
 
     const handleCreate = async () => {
-    console.log("TEST_123");
-alert("TEST_123");
-console.log("STEP_1");
-        console.log('HANDLE CREATE CALLED', { title, description, category, campusId, federatedToAll });
         if (loading) return;
 
         if (!title.trim() || !description.trim() || !category) {
             Alert.alert('Missing Info', 'Please fill Title, Description and Category.');
             return;
         }
-        console.log("STEP_2");
         if (!campusId && !federatedToAll) {
-            Alert.alert('Missing Info', 'Please select a campus or mark the event as open to all campuses.');
+            Alert.alert(
+                'Missing Info',
+                'Please select a campus or mark the event as open to all campuses.',
+            );
             return;
         }
-        console.log("STEP_3");
         if (eventMode === 'offline' && !location.trim()) {
             Alert.alert('Location', 'Please specify a venue.');
             return;
         }
-        console.log("STEP_4");
         if (isPaid && (!price || !upiId)) {
             Alert.alert('Payment Info', 'Price and UPI ID are required for paid events.');
             return;
@@ -420,16 +416,11 @@ console.log("STEP_1");
             return;
         }
         setLoading(true);
-        console.log("STEP_5_BEFORE_RATE_LIMIT");
         try {
             // Symmetrical, client-side rate-limiting checks prior to side-effects
             try {
-                console.log("STEP_6_BEFORE_ENFORCE");
-                // await enforceRateLimit(!isEditMode);
-                 console.log("STEP_7_AFTER_ENFORCE");
-                
+                await enforceRateLimit(!isEditMode);
             } catch (rateLimitErr) {
-                 console.log("STEP_8_RATE_LIMIT_ERROR", rateLimitErr);
                 if (rateLimitErr.status === 429) {
                     Alert.alert('Too Many Requests', rateLimitErr.message);
                     setLoading(false);
@@ -1284,7 +1275,7 @@ console.log("STEP_1");
                     >
                         {loading ? (
                             <View style={styles.submitLoadingContent}>
-                              <ActivityIndicator color="#fff" />
+                                <ActivityIndicator color="#fff" />
                                 <Text style={styles.createBtnText}>{submitLabel}</Text>
                             </View>
                         ) : (

--- a/app/src/screens/CreateEvent.js
+++ b/app/src/screens/CreateEvent.js
@@ -424,8 +424,7 @@ export default function CreateEvent({ navigation, route }) {
                 if (rateLimitErr.status === 429) {
                     Alert.alert('Too Many Requests', rateLimitErr.message);
                     setLoading(false);
-...(federatedToAll ? {} : { campusId }),
-                federatedToAll,                    return;
+                    return;
                 }
                 throw rateLimitErr;
             }
@@ -472,7 +471,7 @@ export default function CreateEvent({ navigation, route }) {
                     years: targetYears.length ? targetYears : [1, 2, 3, 4],
                 },
                 bannerUrl,
-                campusId: campusId || null,
+                ...(federatedToAll ? {} : { campusId }),
                 federatedToAll,
                 capacity: capacity ? Number.parseInt(capacity, 10) : null,
                 hasCustomForm: useCustomForm,

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -153,7 +153,7 @@ const UserFeedStickyHeader = ({
                                 </LinearGradient>
                             ) : (
                                 <View
-                                style={[styles.chip, { backgroundColor: theme.colors.surface }]}
+                                    style={[styles.chip, { backgroundColor: theme.colors.surface }]}
                                 >
                                     <Text
                                         style={[
@@ -398,9 +398,7 @@ export default function UserFeed() {
 
     const visibleEvents = useMemo(() => {
         if (selectedCampus === 'all') return events;
-        return events.filter(
-            e => e.federatedToAll === true || e.campusId === selectedCampus,
-        );
+        return events.filter(e => e.federatedToAll === true || e.campusId === selectedCampus);
     }, [events, selectedCampus]);
 
     const fetchEventsPage = useCallback(async cursorDoc => {
@@ -688,10 +686,18 @@ export default function UserFeed() {
                             paddingVertical: 8,
                             borderRadius: 20,
                             marginRight: 8,
-                            backgroundColor: selectedCampus === opt.id ? theme.colors.primary : theme.colors.surface,
+                            backgroundColor:
+                                selectedCampus === opt.id
+                                    ? theme.colors.primary
+                                    : theme.colors.surface,
                         }}
                     >
-                        <Text style={{ color: selectedCampus === opt.id ? '#fff' : theme.colors.text, fontWeight: '600' }}>
+                        <Text
+                            style={{
+                                color: selectedCampus === opt.id ? '#fff' : theme.colors.text,
+                                fontWeight: '600',
+                            }}
+                        >
                             {opt.name}
                         </Text>
                     </TouchableOpacity>

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -679,34 +679,20 @@ export default function UserFeed() {
                 showsHorizontalScrollIndicator={false}
                 contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 10 }}
             >
-                <TouchableOpacity
-                    onPress={() => setSelectedCampus('all')}
-                    style={{
-                        paddingHorizontal: 16,
-                        paddingVertical: 8,
-                        borderRadius: 20,
-                        marginRight: 8,
-                        backgroundColor: selectedCampus === 'all' ? theme.colors.primary : theme.colors.surface,
-                    }}
-                >
-                    <Text style={{ color: selectedCampus === 'all' ? '#fff' : theme.colors.text, fontWeight: '600' }}>
-                        All Campuses
-                    </Text>
-                </TouchableOpacity>
-                {institutions.map(inst => (
+                {[{ id: 'all', name: 'All Campuses' }, ...institutions].map(opt => (
                     <TouchableOpacity
-                        key={inst.id}
-                        onPress={() => setSelectedCampus(inst.id)}
+                        key={opt.id}
+                        onPress={() => setSelectedCampus(opt.id)}
                         style={{
                             paddingHorizontal: 16,
                             paddingVertical: 8,
                             borderRadius: 20,
                             marginRight: 8,
-                            backgroundColor: selectedCampus === inst.id ? theme.colors.primary : theme.colors.surface,
+                            backgroundColor: selectedCampus === opt.id ? theme.colors.primary : theme.colors.surface,
                         }}
                     >
-                        <Text style={{ color: selectedCampus === inst.id ? '#fff' : theme.colors.text, fontWeight: '600' }}>
-                            {inst.name}
+                        <Text style={{ color: selectedCampus === opt.id ? '#fff' : theme.colors.text, fontWeight: '600' }}>
+                            {opt.name}
                         </Text>
                     </TouchableOpacity>
                 ))}

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -759,7 +759,7 @@ export default function UserFeed() {
                 <Animated.SectionList
                     sections={[{ data: groupedData }]}
                     keyExtractor={row => row.map(e => e.id).join('-')}
-                    
+                    renderItem={renderEvent}
                     renderSectionHeader={renderStickyHeader}
                     ListHeaderComponent={renderHeader}
                     stickySectionHeadersEnabled={true}
@@ -930,4 +930,3 @@ const styles = StyleSheet.create({
         color: '#fff',
     },
 });
-renderItem={renderEvent}

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -153,7 +153,7 @@ const UserFeedStickyHeader = ({
                                 </LinearGradient>
                             ) : (
                                 <View
-                                    style={[styles.chip, { backgroundColor: theme.colors.surface }]}
+                                style={[styles.chip, { backgroundColor: theme.colors.surface }]}
                                 >
                                     <Text
                                         style={[
@@ -194,6 +194,19 @@ export default function UserFeed() {
     const { theme } = useTheme();
     const { width } = useWindowDimensions();
     const [events, setEvents] = useState([]);
+    const [institutions, setInstitutions] = useState([]);
+    const [selectedCampus, setSelectedCampus] = useState('all');
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const snap = await getDocs(collection(db, 'institutions'));
+                setInstitutions(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+            } catch (e) {
+                console.log('Institutions fetch error', e);
+            }
+        })();
+    }, []);
     const [participatingIds, setParticipatingIds] = useState([]); // Track joined events
     const [activeFilter, setActiveFilter] = useState('Upcoming');
     const [searchHistory, setSearchHistory] = useState([]);
@@ -383,6 +396,13 @@ export default function UserFeed() {
         return () => unsubscribe();
     }, [user, isFocused]);
 
+    const visibleEvents = useMemo(() => {
+        if (selectedCampus === 'all') return events;
+        return events.filter(
+            e => e.federatedToAll === true || e.campusId === selectedCampus,
+        );
+    }, [events, selectedCampus]);
+
     const fetchEventsPage = useCallback(async cursorDoc => {
         const constraints = [orderBy('startAt', 'desc')];
         if (cursorDoc) {
@@ -500,7 +520,7 @@ export default function UserFeed() {
 
     const getFilteredEvents = () => {
         const now = new Date();
-        let filtered = events;
+        let filtered = visibleEvents;
 
         // 0. Search Query Filtering
         if (debouncedQuery.trim()) {
@@ -653,6 +673,45 @@ export default function UserFeed() {
 
     const renderHeader = () => (
         <Animated.View style={{ transform: [{ translateY: headerTranslateY }] }}>
+            {/* Campus Filter */}
+            <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 10 }}
+            >
+                <TouchableOpacity
+                    onPress={() => setSelectedCampus('all')}
+                    style={{
+                        paddingHorizontal: 16,
+                        paddingVertical: 8,
+                        borderRadius: 20,
+                        marginRight: 8,
+                        backgroundColor: selectedCampus === 'all' ? theme.colors.primary : theme.colors.surface,
+                    }}
+                >
+                    <Text style={{ color: selectedCampus === 'all' ? '#fff' : theme.colors.text, fontWeight: '600' }}>
+                        All Campuses
+                    </Text>
+                </TouchableOpacity>
+                {institutions.map(inst => (
+                    <TouchableOpacity
+                        key={inst.id}
+                        onPress={() => setSelectedCampus(inst.id)}
+                        style={{
+                            paddingHorizontal: 16,
+                            paddingVertical: 8,
+                            borderRadius: 20,
+                            marginRight: 8,
+                            backgroundColor: selectedCampus === inst.id ? theme.colors.primary : theme.colors.surface,
+                        }}
+                    >
+                        <Text style={{ color: selectedCampus === inst.id ? '#fff' : theme.colors.text, fontWeight: '600' }}>
+                            {inst.name}
+                        </Text>
+                    </TouchableOpacity>
+                ))}
+            </ScrollView>
+
             {/* Friends Events Rail */}
             {friendsEvents.length > 0 && (
                 <View style={{ marginBottom: 20 }}>
@@ -714,7 +773,7 @@ export default function UserFeed() {
                 <Animated.SectionList
                     sections={[{ data: groupedData }]}
                     keyExtractor={row => row.map(e => e.id).join('-')}
-                    renderItem={renderEvent}
+                    
                     renderSectionHeader={renderStickyHeader}
                     ListHeaderComponent={renderHeader}
                     stickySectionHeadersEnabled={true}
@@ -885,3 +944,4 @@ const styles = StyleSheet.create({
         color: '#fff',
     },
 });
+renderItem={renderEvent}

--- a/app/src/screens/__tests__/CreateEvent.test.js
+++ b/app/src/screens/__tests__/CreateEvent.test.js
@@ -203,8 +203,9 @@ describe('CreateEvent transaction flow', () => {
         );
         fireEvent.changeText(getByPlaceholderText('e.g. Auditorium / Room 302'), 'Main Hall');
 
-        fireEvent.press(getByText('Tech'));
-        fireEvent.press(getAllByText('Create Event').at(1));
+       fireEvent.press(getByText('Tech'));
+fireEvent.press(getByText('Open to All Campuses'));
+fireEvent.press(getAllByText('Create Event').at(1));
 
         await waitFor(() => {
             expect(mockRunTransaction).toHaveBeenCalledTimes(1);

--- a/app/src/screens/__tests__/CreateEvent.test.js
+++ b/app/src/screens/__tests__/CreateEvent.test.js
@@ -203,9 +203,9 @@ describe('CreateEvent transaction flow', () => {
         );
         fireEvent.changeText(getByPlaceholderText('e.g. Auditorium / Room 302'), 'Main Hall');
 
-       fireEvent.press(getByText('Tech'));
-fireEvent.press(getByText('Open to All Campuses'));
-fireEvent.press(getAllByText('Create Event').at(1));
+        fireEvent.press(getByText('Tech'));
+        fireEvent.press(getByText('Open to All Campuses'));
+        fireEvent.press(getAllByText('Create Event').at(1));
 
         await waitFor(() => {
             expect(mockRunTransaction).toHaveBeenCalledTimes(1);

--- a/app/src/screens/__tests__/CreateEvent.test.js
+++ b/app/src/screens/__tests__/CreateEvent.test.js
@@ -167,6 +167,7 @@ jest.mock('firebase/firestore', () => ({
     runTransaction: (...args) => mockRunTransaction(...args),
     increment: (...args) => mockIncrement(...args),
     serverTimestamp: (...args) => mockServerTimestamp(...args),
+    getDocs: jest.fn(() => Promise.resolve({ docs: [] })),
 }));
 
 import { Alert } from 'react-native';

--- a/firestore.rules
+++ b/firestore.rules
@@ -124,8 +124,14 @@ service cloud.firestore {
       return get(/databases/$(database)/documents/users/$(userId)).data;
     }
 
+    function getUserCampus() {
+      return exists(/databases/$(database)/documents/users/$(request.auth.uid))
+        ? getUserData(request.auth.uid).get('campusId', null)
+        : null;
+    }
+
     function isSameCampus(campusId) {
-      return getUserData(request.auth.uid).get('campusId', null) == campusId;
+      return getUserCampus() == campusId;
     }
 
   
@@ -273,7 +279,7 @@ service cloud.firestore {
         isAdmin() ||
         (resource.data.get('federatedToAll', false) == true) ||
         isSameCampus(resource.data.get('campusId', null)) ||
-        (getUserData(request.auth.uid).get('campusId', null) in resource.data.get('allowedCampusIds', []))
+        (getUserCampus() != null && getUserCampus() in resource.data.get('allowedCampusIds', []))
       );
       
       // Write operations with rate limit checks

--- a/firestore.rules
+++ b/firestore.rules
@@ -19,7 +19,9 @@ service cloud.firestore {
     }
 
     function validateEventShape(data) {
-      return isValidEventTitle(data) && isValidEventCapacity(data) && isValidEventDate(data);
+      return isValidEventTitle(data) && isValidEventCapacity(data) && isValidEventDate(data)
+        && (!('campusId' in data) || data.campusId is string)
+        && (!('federatedToAll' in data) || data.federatedToAll is bool);
     }
 
     function isValidThemeColor(data) {
@@ -122,6 +124,11 @@ service cloud.firestore {
       return get(/databases/$(database)/documents/users/$(userId)).data;
     }
 
+    function isSameCampus(campusId) {
+      return getUserData(request.auth.uid).get('campusId', null) == campusId;
+    }
+
+  
     // Validate that updates to the rate-limit fields are strictly valid increments or resets
     function validateRateLimitUpdate(userId) {
       let before = resource.data;
@@ -262,7 +269,12 @@ service cloud.firestore {
     // =========================================================================
 
     match /events/{eventId} {
-      allow read: if request.auth != null;
+      allow read: if request.auth != null && (
+        isAdmin() ||
+        (resource.data.get('federatedToAll', false) == true) ||
+        isSameCampus(resource.data.get('campusId', null)) ||
+        (getUserData(request.auth.uid).get('campusId', null) in resource.data.get('allowedCampusIds', []))
+      );
       
       // Write operations with rate limit checks
       allow create: if request.auth != null 

--- a/firestore.rules
+++ b/firestore.rules
@@ -279,15 +279,14 @@ service cloud.firestore {
     // EVENTS COLLECTION & SUBCOLLECTIONS
     // =========================================================================
 
-    match /events/{eventId} {
+   match /events/{eventId} {
       allow read: if request.auth != null && (
         isAdmin() ||
         (resource.data.get('federatedToAll', false) == true) ||
         isSameCampus(resource.data.get('campusId', null)) ||
         (getUserCampus() != null && getUserCampus() in resource.data.get('allowedCampusIds', []))
       );
-      
-      // Write operations with rate limit checks
+
       allow create: if request.auth != null 
                     && (isAdmin() || (isClub() && checkWriteRate(request.auth.uid) && checkEventDailyRate(request.auth.uid)))
                     && validateEventShape(request.resource.data)
@@ -300,7 +299,6 @@ service cloud.firestore {
       allow delete: if request.auth != null 
                     && (isAdmin() || ('ownerId' in resource.data && request.auth.uid == resource.data.ownerId));
 
-      // Attendance fallback subcollection
       match /attendance/{attendanceId} {
          allow read: if request.auth != null && (
            isAdmin() ||
@@ -316,7 +314,9 @@ service cloud.firestore {
              isEventOwner(database, eventId) ||
              isEventOwnerAfter(database, eventId)
            );
-      }
+    }
+
+      // Event Participants Registry
 
       // Event Participants Registry
       match /participants/{participantId} {
@@ -392,13 +392,20 @@ service cloud.firestore {
           isClub()
         ) && (!('userId' in request.resource.data) || request.resource.data.userId == request.auth.uid);
       }
-      
       // Volunteers List
       match /volunteers/{userId} {
         allow read: if true;
         // All writes must go through Cloud Functions to ensure proper point logging
         allow create, update, delete: if false; 
       }
+    }
+
+    match /eventTemplates/{templateId} {
+      allow read: if request.auth != null && request.auth.uid == resource.data.ownerId;
+      allow create: if request.auth != null
+                    && request.auth.uid == request.resource.data.ownerId;
+      allow update, delete: if request.auth != null
+                             && request.auth.uid == resource.data.ownerId;
     }
     
     // =========================================================================

--- a/firestore.rules
+++ b/firestore.rules
@@ -253,6 +253,11 @@ service cloud.firestore {
       allow update, delete: if isAdmin();
     }
 
+    match /institutions/{institutionId} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
     // Root-level Certificates Collection
     match /certificates/{certId} {
       allow read: if request.auth != null && (
@@ -285,7 +290,8 @@ service cloud.firestore {
       // Write operations with rate limit checks
       allow create: if request.auth != null 
                     && (isAdmin() || (isClub() && checkWriteRate(request.auth.uid) && checkEventDailyRate(request.auth.uid)))
-                    && validateEventShape(request.resource.data);
+                    && validateEventShape(request.resource.data)
+                    && exists(/databases/$(database)/documents/institutions/$(request.resource.data.campusId));
       
       allow update: if request.auth != null 
                     && (isAdmin() || ('ownerId' in resource.data && request.auth.uid == resource.data.ownerId && checkWriteRate(request.auth.uid)))


### PR DESCRIPTION
Part 1 of the multi-campus federation feature (#674).

Adds:
- `isSameCampus()` helper function
- Campus-aware read rule for the `events` collection: allows read if federated to all campuses, matches the user's campus, is in an explicit allowed-campus list, or reader is admin
- `campusId` / `federatedToAll` type validation in `validateEventShape()`

Note: existing events without a `campusId` field remain readable by users who also have no `campusId` set, to avoid breaking access to legacy data during rollout. This should be revisited once the campus backfill (Phase 2) is complete.

This is a partial implementation. Schema fields on write paths, the `institutions` collection, Discover page filtering, event creation UI, and admin campus management will follow in subsequent PRs.

Related to #674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added campus-based event visibility, including “All Campuses” federation and campus-targeted access.
  * Introduced campus selection in the user feed and campus-targeting badges on event cards.
  * Added event templates for saving and reusing event details.
  * Added event previews before submission.
  * Enabled public institution browsing with admin-controlled changes.
* **Bug Fixes**
  * Strengthened event validation and access controls, including campus verification for new events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->