### PR TITLE
fix: allow event owner to write participant check-in fields (#753)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -336,9 +336,21 @@ service cloud.firestore {
           
         allow delete: if request.auth != null && request.auth.uid == participantId;
         
-        allow update: if request.auth != null && request.auth.uid == participantId &&
-          validateAttendanceStatus(request.resource.data) &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'buddyPreference', 'updatedAt']);
+        allow update: if request.auth != null && (
+          (
+            request.auth.uid == participantId &&
+            validateAttendanceStatus(request.resource.data) &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'buddyPreference', 'updatedAt'])
+          ) || (
+            // Organizer/owner check-in writes (Issue #753): the frontend
+            // marks a participant as checked-in via checkInParticipant(),
+            // which runs as the organizer, not the participant. Restrict
+            // owner updates to the check-in fields only.
+            isEventOwner(database, eventId) &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['checkInStatus', 'checkedInAt', 'checkedInBy']) &&
+            (!('checkInStatus' in request.resource.data) || request.resource.data.checkInStatus in ['checked-in', 'checked-out'])
+          )
+        );
       }
 
       // Event Check-ins (Contactless Verification)

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -342,6 +342,52 @@ describe('Firestore Security Rules', () => {
         );
     });
 
+    // Issue #753: free-RSVP check-in runs as the organizer; the owner may
+    // write only the check-in fields on a participant document.
+    test('Event owner marks participant checked-in -> allowed', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', { status: 'attending' });
+        await assertSucceeds(
+            setDoc(
+                doc(getFirestoreContext('clubOwner1'), 'events/event1/participants/student1'),
+                {
+                    checkInStatus: 'checked-in',
+                    checkedInAt: serverTimestamp(),
+                    checkedInBy: 'clubOwner1',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
+    test('Event owner writes non-check-in field on participant -> denied', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', { status: 'attending' });
+        await assertFails(
+            setDoc(
+                doc(getFirestoreContext('clubOwner1'), 'events/event1/participants/student1'),
+                { status: 'cancelled' },
+                { merge: true },
+            ),
+        );
+    });
+
+    test('Non-owner organizer writes check-in fields on participant -> denied', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', { status: 'attending' });
+        await assertFails(
+            setDoc(
+                doc(getFirestoreContext('otherUser'), 'events/event1/participants/student1'),
+                {
+                    checkInStatus: 'checked-in',
+                    checkedInAt: serverTimestamp(),
+                    checkedInBy: 'otherUser',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
     test("Student deletes another user's participant record -> denied", async () => {
         await seedDocument('events/event1/participants/student2', { joined: true });
         await assertFails(


### PR DESCRIPTION
Closes #753

## Problem
`checkInParticipant()` runs as the organizer and writes `checkInStatus`/`checkedInAt`/`checkedInBy` on `events/{eventId}/participants/{participantId}`, but the Firestore update rule only permitted the `participant themselves` to write `status`/`buddyPreference`/`updatedAt`. The denied write fails the atomic transaction, so free-RSVP check-in always returned `Unable to complete check-in`.

## Fix
Extended the participants `allow update` rule: the event owner (`isEventOwner`) may now write only the three check-in fields, with `checkInStatus` validated to `['checked-in','checked-out']`. All other owner writes to participant docs remain denied, and participant-only self-updates are unchanged.

## Verification
- Added 3 security-rule tests (owner check-in allowed; owner non-check-in field denied; non-owner check-in denied).
- `npm run test:rules`: 49 passed (was 46 on baseline; the 4 remaining failures are pre-existing on main, unrelated to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event participant update permissions.
  * Event owners can update valid check-in details without changing other participant information.
  * Participants retain access to permitted attendance and profile updates.
  * Unauthorized check-in changes are blocked.

* **Tests**
  * Added coverage for owner and non-owner check-in update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->