### PR TITLE
fix: fail loudly on malformed Firebase credential JSON (#613)

### DIFF
--- a/cloud-functions/src/server.test.ts
+++ b/cloud-functions/src/server.test.ts
@@ -1,0 +1,62 @@
+jest.mock('firebase-admin', () => ({
+    apps: [],
+    initializeApp: jest.fn(),
+    credential: {
+        cert: jest.fn(cert => {
+            if (!cert || !cert.private_key || !cert.client_email || !cert.project_id) {
+                throw new Error(
+                    'Credential implementation provided to initializeApp() must be an object with private_key, client_email and project_id',
+                );
+            }
+            return { cert };
+        }),
+    },
+}));
+
+const admin = require('firebase-admin');
+const { initFirebaseAdmin } = require('./server');
+
+describe('initFirebaseAdmin', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        admin.apps.length = 0;
+    });
+
+    test('throws a critical error on malformed credential JSON instead of falling back', () => {
+        expect(() => initFirebaseAdmin('{not valid json')).toThrow(
+            /Failed to parse GOOGLE_APPLICATION_CREDENTIALS_JSON.*Refusing to fall back/,
+        );
+        expect(admin.initializeApp).not.toHaveBeenCalled();
+    });
+
+    test('throws on structurally invalid but parseable credential JSON (missing private_key)', () => {
+        expect(() =>
+            initFirebaseAdmin(JSON.stringify({ project_id: 'x', client_email: 'a@b.c' })),
+        ).toThrow(/Failed to initialize GOOGLE_APPLICATION_CREDENTIALS_JSON/);
+        expect(admin.initializeApp).not.toHaveBeenCalled();
+    });
+
+    test('initializes from env credentials when JSON is valid', () => {
+        const valid = JSON.stringify({
+            project_id: 'p',
+            client_email: 'a@b.c',
+            private_key: 'KEY',
+        });
+        const source = initFirebaseAdmin(valid);
+        expect(source).toBe('env');
+        expect(admin.initializeApp).toHaveBeenCalledTimes(1);
+    });
+
+    test('falls back to default credentials when env var is absent', () => {
+        const source = initFirebaseAdmin(undefined);
+        expect(source).toBe('default');
+        expect(admin.initializeApp).toHaveBeenCalledTimes(1);
+        expect(admin.initializeApp).toHaveBeenCalledWith();
+    });
+
+    test('is a no-op when Admin is already initialized', () => {
+        admin.apps.length = 1;
+        initFirebaseAdmin('{"broken":');
+        expect(admin.initializeApp).not.toHaveBeenCalled();
+    });
+});

--- a/cloud-functions/src/server.ts
+++ b/cloud-functions/src/server.ts
@@ -7,27 +7,59 @@ import { checkAndUpdateRateLimit } from './utils/rateLimiter';
 // Load environment variables
 dotenv.config();
 
-// Initialize Firebase Admin (ensure service account is available or uses default credentials)
-// For Render, we might need to rely on strict env vars or a service account file
-if (admin.apps.length === 0) {
-    // Try to load credentials from environment variable
-    const credentialsJson = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+export type FirebaseCredentialSource = 'env' | 'default';
+
+/**
+ * Initializes Firebase Admin. When `GOOGLE_APPLICATION_CREDENTIALS_JSON` is
+ * set but malformed, this fails loudly instead of silently falling back to
+ * Application Default Credentials (Issue #613): a misconfigured credential
+ * must never quietly run with unintended privileges.
+ */
+export const initFirebaseAdmin = (
+    credentialsJson: string | undefined = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON,
+): FirebaseCredentialSource => {
+    if (admin.apps.length > 0) {
+        return 'default';
+    }
 
     if (credentialsJson) {
+        let serviceAccount: admin.ServiceAccount;
         try {
-            const serviceAccount = JSON.parse(credentialsJson);
+            serviceAccount = JSON.parse(credentialsJson);
+        } catch (error) {
+            throw new Error(
+                '❌ Failed to parse GOOGLE_APPLICATION_CREDENTIALS_JSON: ' +
+                    (error instanceof Error ? error.message : String(error)) +
+                    '. Refusing to fall back to default credentials.',
+            );
+        }
+        try {
             admin.initializeApp({
                 credential: admin.credential.cert(serviceAccount),
             });
-            console.log('✅ Firebase Admin initialized with service account from env');
         } catch (error) {
-            console.error('❌ Failed to parse service account JSON:', error);
-            admin.initializeApp();
+            throw new Error(
+                '❌ Failed to initialize GOOGLE_APPLICATION_CREDENTIALS_JSON (' +
+                    (error instanceof Error ? error.message : String(error)) +
+                    '). Refusing to fall back to default credentials.',
+            );
         }
-    } else {
-        // Fallback to default credentials
-        admin.initializeApp();
-        console.log('⚠️  Firebase Admin initialized with default credentials');
+        console.log('✅ Firebase Admin initialized with service account from env');
+        return 'env';
+    }
+
+    // Fallback to default credentials
+    admin.initializeApp();
+    console.log('⚠️  Firebase Admin initialized with default credentials');
+    return 'default';
+};
+
+if (admin.apps.length === 0) {
+    try {
+        initFirebaseAdmin();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+        throw error;
     }
 }
 
@@ -347,6 +379,10 @@ app.get('/', (req, res) => {
 
 // Start Server
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-    console.log(`Server running on port ${PORT}`);
-});
+
+// Skip actually listening during unit tests (the module is imported directly there)
+if (process.env.NODE_ENV !== 'test') {
+    app.listen(PORT, () => {
+        console.log(`Server running on port ${PORT}`);
+    });
+}


### PR DESCRIPTION
Closes #613

## Problem
When `GOOGLE_APPLICATION_CREDENTIALS_JSON` was set but malformed, `server.ts` logged the parse error and silently fell back to Application Default Credentials — hiding misconfigurations and risking running production with unintended privileges.

## Fix
- Extracted `initFirebaseAdmin()`; malformed JSON now throws a critical error naming the env var and explicitly refuses to fall back to default credentials.
- `admin.credential.cert()` failures (structurally invalid credential) also throw instead of falling back.
- Module no longer calls `app.listen()` under `NODE_ENV=test`, so the init logic is unit-testable.

## Verification
- 5 new unit tests in `cloud-functions/src/server.test.ts` (malformed JSON throws, no init; invalid credential throws; valid env init; ADC fallback; already-initialized no-op) — all pass.
- `npx eslint` clean; `tsc -p tsconfig.build.json --noEmit` clean.