### PR TITLE
fix: add Content Security Policy and security headers to hosting (#578)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,33 @@
                 "source": "**",
                 "destination": "/index.html"
             }
+        ],
+        "headers": [
+            {
+                "source": "**",
+                "headers": [
+                    {
+                        "key": "Content-Security-Policy",
+                        "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
+                    },
+                    {
+                        "key": "X-Frame-Options",
+                        "value": "DENY"
+                    },
+                    {
+                        "key": "X-Content-Type-Options",
+                        "value": "nosniff"
+                    },
+                    {
+                        "key": "Referrer-Policy",
+                        "value": "strict-origin-when-cross-origin"
+                    },
+                    {
+                        "key": "Permissions-Policy",
+                        "value": "camera=(), microphone=(), geolocation=()"
+                    }
+                ]
+            }
         ]
     },
     "functions": {


### PR DESCRIPTION
Closes #578

## Problem
Web deployment shipped with no CSP or hardening headers — inline XSS payloads would execute and the app could be framed by malicious sites.

## Fix
Added a headers block to the hosting section of `firebase.json`:
- **CSP**: `default-src 'self'`; scripts from self only; `'unsafe-inline'` for styles only (React Native Web renders inline style attributes); `https:` for connect-src (Firestore, functions, Firebase Auth); blob/data sources for images; `frame-ancestors 'none'`; `object-src 'none'`.
- **X-Frame-Options: DENY**, **X-Content-Type-Options: nosniff**, **Referrer-Policy: strict-origin-when-cross-origin**, **Permissions-Policy** (camera/mic/geolocation blocked).

## Verification
`firebase.json` parses as valid JSON (`python3 -m json.tool`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added security-focused HTTP headers across all hosted routes.
  * Improved protection against framing, MIME-type sniffing, referrer leakage, and unauthorized browser feature access.
  * Added a Content Security Policy to help restrict unsafe resource loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->