### PR TITLE
fix: reject check-ins from non-owners before writing (#623)

### DIFF
--- a/app/src/screens/QRScannerScreen.js
+++ b/app/src/screens/QRScannerScreen.js
@@ -204,6 +204,23 @@ export default function QRScannerScreen({ navigation, route }) {
                 return;
             }
 
+            // Security: only the event owner (or an admin) may record a
+            // check-in on behalf of an attendee. Rules enforce this too,
+            // but verifying up-front prevents ghost attendance attempts
+            // from reaching the database and gives a clear error (#623).
+            const eventSnap = await getDoc(doc(db, 'events', eventId)).catch(() => null);
+            const ownerId = eventSnap?.data()?.ownerId;
+            const isOwner = ownerId && user && user.uid === ownerId;
+            const isAdmin = user?.role === 'admin';
+            if (!isOwner && !isAdmin) {
+                setScanResult({
+                    status: 'error',
+                    message:
+                        'Only the event organizer (or an admin) can check in attendees.',
+                });
+                return;
+            }
+
             const { ticketData, scannedUserId } = parsedScan;
             const hasTicketId = Boolean(ticketData?.ticketId);
             const operatorName = getOperatorName(user);


### PR DESCRIPTION
Closes #623

## Problem
The QR check-in flow recorded attendance purely client-side without verifying the operator was authorized. Any authenticated user who obtained someone else's QR could check them in — ghost attendance records and inflated leaderboard scores. Firestore rules already reject the underlying write, but the client attempted it blindly and showed only generic errors.

## Fix
`handleBarCodeScanned` now reads the event document up-front and requires the scanning user to be the event `ownerId` (or an admin with role `admin`) before any check-in write is attempted. Unauthorized scans are rejected with a clear message before reaching the database — this also short-circuits the queued-offline path.

## Verification
- The rules-level guard is already covered by `tests/firestore.rules.test.ts` (`Student writes event check-in -> denied`).
- Existing QRScannerScreen camera-permission tests unaffected (change only touches the scan handler).