### PR TITLE
feat: add 'No Events Found' empty state UI (#386)

### DIFF
--- a/app/src/components/EmptyState.js
+++ b/app/src/components/EmptyState.js
@@ -1,0 +1,74 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * Shared friendly empty state (#386): icon with a gentle float animation,
+ * a headline message and an optional hint line.
+ */
+export default function EmptyState({ icon, title, subtitle, theme }) {
+    const float = useRef(new Animated.Value(0)).current;
+
+    useEffect(() => {
+        const animation = Animated.loop(
+            Animated.sequence([
+                Animated.timing(float, {
+                    toValue: -6,
+                    duration: 1200,
+                    useNativeDriver: true,
+                }),
+                Animated.timing(float, {
+                    toValue: 0,
+                    duration: 1200,
+                    useNativeDriver: true,
+                }),
+            ]),
+        );
+        animation.start();
+        return () => animation.stop();
+    }, [float]);
+
+    return (
+        <View style={styles.container}>
+            <Animated.View style={{ transform: [{ translateY: float }] }}>
+                <Ionicons
+                    name={icon || 'calendar-outline'}
+                    size={64}
+                    color={theme.colors.textSecondary}
+                    style={{ opacity: 0.5 }}
+                />
+            </Animated.View>
+            <Text style={[styles.title, { color: theme.colors.textSecondary }]}>
+                {title || 'Nothing here yet!'}
+            </Text>
+            {subtitle ? (
+                <Text style={[styles.subtitle, { color: theme.colors.textSecondary }]}>
+                    {subtitle}
+                </Text>
+            ) : null}
+        </View>
+    );
+}
+
+EmptyState.propTypes = {
+    icon: PropTypes.string,
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    theme: PropTypes.shape({
+        colors: PropTypes.shape({
+            textSecondary: PropTypes.string.isRequired,
+        }).isRequired,
+    }).isRequired,
+};
+
+const styles = StyleSheet.create({
+    container: { alignItems: 'center', marginTop: 50, padding: 20 },
+    title: { marginTop: 16, fontSize: 16, fontWeight: '600' },
+    subtitle: {
+        marginTop: 8,
+        fontSize: 13,
+        textAlign: 'center',
+        opacity: 0.75,
+    },
+});

--- a/app/src/components/__tests__/EmptyState.test.js
+++ b/app/src/components/__tests__/EmptyState.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import EmptyState from '../EmptyState';
+
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const { Text } = require('react-native');
+
+    const MockIcon = ({ name }) => React.createElement(Text, null, name);
+    MockIcon.propTypes = {
+        name: PropTypes.string,
+    };
+
+    return {
+        Ionicons: MockIcon,
+    };
+});
+
+const theme = {
+    colors: {
+        textSecondary: '#666',
+    },
+};
+
+describe('EmptyState', () => {
+    it('renders the title and subtitle', () => {
+        const { getByText } = render(
+            <EmptyState
+                icon="calendar-outline"
+                title="No events yet!"
+                subtitle="Check back soon for new events near you."
+                theme={theme}
+            />,
+        );
+
+        expect(getByText('No events yet!')).toBeTruthy();
+        expect(getByText('Check back soon for new events near you.')).toBeTruthy();
+        expect(getByText('calendar-outline')).toBeTruthy();
+    });
+
+    it('does not render a subtitle when none is provided', () => {
+        const { queryByText, getByText } = render(
+            <EmptyState icon="search-outline" title="No results" theme={theme} />,
+        );
+
+        expect(getByText('No results')).toBeTruthy();
+        expect(queryByText(/Check back soon/)).toBeNull();
+    });
+
+    it('falls back to the default title when omitted', () => {
+        const { getByText } = render(<EmptyState theme={theme} />);
+        expect(getByText('Nothing here yet!')).toBeTruthy();
+    });
+});

--- a/app/src/screens/UserFeed.js
+++ b/app/src/screens/UserFeed.js
@@ -14,6 +14,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import PropTypes from 'prop-types';
+import EmptyState from '../components/EmptyState';
 import {
     Animated,
     ActivityIndicator,
@@ -775,19 +776,20 @@ export default function UserFeed() {
                     onScrollEndDrag={handleScrollEndDrag}
                     contentContainerStyle={{ paddingBottom: 100 }}
                     ListEmptyComponent={
-                        <View style={styles.emptyContainer}>
-                            <Ionicons
-                                name="search-outline"
-                                size={64}
-                                color={theme.colors.textSecondary}
-                                style={{ opacity: 0.5 }}
-                            />
-                            <Text style={[styles.emptyText, { color: theme.colors.textSecondary }]}>
-                                {searchQuery
+                        <EmptyState
+                            icon={searchQuery ? 'search-outline' : 'calendar-outline'}
+                            title={
+                                searchQuery
                                     ? `No events found for "${searchQuery}"`
-                                    : 'No events found.'}
-                            </Text>
-                        </View>
+                                    : 'No events yet!'
+                            }
+                            subtitle={
+                                searchQuery
+                                    ? 'Try a different search term or check your filters.'
+                                    : 'Check back soon for new events near you.'
+                            }
+                            theme={theme}
+                        />
                     }
                     ListFooterComponent={
                         hasMore && events.length > 0 ? (
@@ -917,8 +919,6 @@ const styles = StyleSheet.create({
         color: '#fff',
         opacity: 0.9,
     },
-    emptyContainer: { alignItems: 'center', marginTop: 50, padding: 20 },
-    emptyText: { marginTop: 10, fontSize: 16 },
     loadMoreBtn: {
         backgroundColor: '#6C63FF',
         paddingVertical: 14,


### PR DESCRIPTION
Closes #386

## Problem
When the events feed is empty, the screen showed only a bare `No events found.` line — users could not tell whether the app was loading, broken, or simply had nothing upcoming.

## Changes
- **`app/src/components/EmptyState.js`** (new, shared): icon with a gentle float animation, headline message, optional hint line; theme-aware.
- **`app/src/screens/UserFeed.js`**: `ListEmptyComponent` now renders the friendly empty state:
  - feed empty → "No events yet! Check back soon for new events near you."
  - search query empty → "No events found for \"…\"" + "Try a different search term or check your filters."
- **`app/src/components/__tests__/EmptyState.test.js`**: 3 tests (title+subtitle+icon, no-subtitle, default title).

Pure frontend change — no backend or Firebase changes.