### PR TITLE
feat: deep link push notifications to the event page (#170)

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,5 +1,5 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, createNavigationContainerRef } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as NavigationBar from 'expo-navigation-bar';
 import * as Notifications from 'expo-notifications';
@@ -19,6 +19,10 @@ import { AuthProvider, useAuth } from './src/lib/AuthContext';
 import { ThemeProvider, useTheme } from './src/lib/ThemeContext';
 import { db } from './src/lib/firebaseConfig';
 import { BASE_URL } from './src/lib/config';
+import {
+    extractEventIdFromNotification,
+    waitForNavigationReady,
+} from './src/lib/notificationLinks';
 import { registerForPushNotificationsAsync } from './src/lib/notificationService';
 import AdminDashboard from './src/screens/AdminDashboard';
 import AttendanceDashboard from './src/screens/AttendanceDashboard';
@@ -64,6 +68,21 @@ LazyScreenFallback.propTypes = {
 
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
+
+const navigationRef = createNavigationContainerRef();
+
+/**
+ * Navigates to an event's detail screen, queuing the navigation until the
+ * navigation container is ready (needed for cold-start notification taps,
+ * where the tap arrives before the tree mounts).
+ */
+async function navigateToEvent(eventId) {
+    if (!eventId) return;
+    const ready = await waitForNavigationReady(() => navigationRef.isReady());
+    if (ready) {
+        navigationRef.navigate('EventDetail', { eventId });
+    }
+}
 
 function HomeScreen({ navigation }) {
     const { user, role } = useAuth();
@@ -228,7 +247,7 @@ function Navigation() {
     }
 
     return (
-        <NavigationContainer linking={linking}>
+        <NavigationContainer linking={linking} ref={navigationRef}>
             <Stack.Navigator
                 screenOptions={{
                     headerStyle: {
@@ -423,9 +442,23 @@ function AppContent() {
 
         responseListener.current = Notifications.addNotificationResponseReceivedListener(
             response => {
-                console.log('Notification Tapped:', response);
+                const eventId = extractEventIdFromNotification(response.notification);
+                if (eventId) {
+                    navigateToEvent(eventId);
+                } else {
+                    console.log('Notification Tapped (no event payload):', response);
+                }
             },
         );
+
+        // Cold start: handle a notification tap that launched the app
+        Notifications.getLastNotificationResponseAsync()
+            .then(lastResponse => {
+                if (!lastResponse) return;
+                const eventId = extractEventIdFromNotification(lastResponse.notification);
+                if (eventId) navigateToEvent(eventId);
+            })
+            .catch(err => console.log('Failed to read last notification response', err));
 
         return () => {
             if (notificationListener.current)

--- a/app/src/lib/__tests__/notificationLinks.test.js
+++ b/app/src/lib/__tests__/notificationLinks.test.js
@@ -1,0 +1,72 @@
+import { extractEventIdFromNotification, waitForNavigationReady } from './notificationLinks';
+
+describe('extractEventIdFromNotification', () => {
+    it('returns data.eventId directly', () => {
+        const tapped = {
+            notification: {
+                request: { content: { data: { eventId: 'evt-123' } } },
+            },
+        };
+        expect(extractEventIdFromNotification(tapped)).toBe('evt-123');
+    });
+
+    it('parses the event id from a /event/{id} url', () => {
+        const tapped = {
+            notification: {
+                request: { content: { data: { url: '/event/evt-456' } } },
+            },
+        };
+        expect(extractEventIdFromNotification(tapped)).toBe('evt-456');
+    });
+
+    it('parses the event id from a full scheme url', () => {
+        const tapped = {
+            notification: {
+                request: { content: { data: { url: 'unievent://event/evt-789?t=1' } } },
+            },
+        };
+        expect(extractEventIdFromNotification(tapped)).toBe('evt-789');
+    });
+
+    it('returns null for payloads without an event reference', () => {
+        expect(
+            extractEventIdFromNotification({
+                notification: { request: { content: { data: {} } } },
+            }),
+        ).toBeNull();
+        expect(extractEventIdFromNotification(null)).toBeNull();
+        expect(
+            extractEventIdFromNotification({
+                notification: { request: { content: { data: { url: '/leaderboard' } } } },
+            }),
+        ).toBeNull();
+    });
+});
+
+describe('waitForNavigationReady', () => {
+    it('resolves immediately when already ready', async () => {
+        const ready = jest.fn(() => true);
+        await expect(waitForNavigationReady(ready)).resolves.toBe(true);
+        expect(ready).toHaveBeenCalledTimes(1);
+    });
+
+    it('polls until ready and then resolves true', async () => {
+        jest.useFakeTimers();
+        let isReadyNow = false;
+        const resolve = waitForNavigationReady(() => isReadyNow, 5, 100);
+        isReadyNow = true;
+        await jest.runAllTimersAsync();
+        await expect(resolve).resolves.toBe(true);
+        jest.useRealTimers();
+    });
+
+    it('returns false after exhausting retries', async () => {
+        jest.useFakeTimers();
+        const ready = jest.fn(() => false);
+        const resolve = waitForNavigationReady(ready, 3, 100);
+        await jest.runAllTimersAsync();
+        await expect(resolve).resolves.toBe(false);
+        expect(ready).toHaveBeenCalledTimes(4);
+        jest.useRealTimers();
+    });
+});

--- a/app/src/lib/notificationLinks.js
+++ b/app/src/lib/notificationLinks.js
@@ -1,0 +1,32 @@
+/**
+ * Push-notification deep-linking helpers (#170): extract the target event
+ * from a tapped notification payload so the app can navigate directly to
+ * the event page instead of the home screen.
+ */
+
+/**
+ * Resolves the event id from a notification's data payload.
+ * Accepts either `data.eventId` or a URL-style `data.url` like
+ * `/event/{eventId}` or `unievent://event/{eventId}`.
+ */
+export function extractEventIdFromNotification(tappedNotification) {
+    const data = tappedNotification?.request?.content?.data ?? {};
+    if (data.eventId) return String(data.eventId);
+    const url = typeof data.url === 'string' ? data.url : '';
+    const match = url.match(/\/event\/([^/?]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return null;
+}
+
+/**
+ * Waits for the navigation container to become ready (bounded) and returns
+ * a boolean indicating availability, so callers can navigate safely on
+ * cold-start taps.
+ */
+export async function waitForNavigationReady(isReady, maxRetries = 20, delayMs = 250) {
+    for (let i = 0; i < maxRetries; i += 1) {
+        if (isReady()) return true;
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    return isReady();
+}


### PR DESCRIPTION
Closes #170

## Problem
Tapping an event-reminder or RSVP push notification landed users on the home screen — `response.data.url` (`/event/{eventId}`) was merely console-logged, so the notification payload never drove navigation.

## Changes
- **`app/App.js`**: `navigationRef` mounted on `NavigationContainer`; notification-tap handler now navigates to `EventDetail` with the tapped event's id; navigation is queued (bounded poll) until the nav tree is ready, so cold-start taps work too. Cold-start launch-tap handled via `Notifications.getLastNotificationResponseAsync()`.
- **`app/src/lib/notificationLinks.js`** (new): `extractEventIdFromNotification` (supports `data.eventId`, `/event/{id}` and `unievent://event/{id}` forms) + `waitForNavigationReady`.
- **`app/src/lib/__tests__/notificationLinks.test.js`**: 7 tests (eventId direct, path/scheme URL parsing, no-event fallback, ready poll success/timeout).

## Verification
- `prettier --check` clean on all touched files.
- App jest tests cannot execute in this sandbox (repo-declared `jest-expo` preset not installed locally); tests follow the existing `usePushNotifications.test.js` conventions and will run in CI.