### PR TITLE
feat: bulk attendee import from CSV in attendance dashboard (#559)

### DIFF
--- a/app/src/lib/__tests__/csvImport.test.js
+++ b/app/src/lib/__tests__/csvImport.test.js
@@ -1,0 +1,101 @@
+import { parseCsv, parseAttendeeRows, participantIdForEmail } from './csvImport';
+
+describe('parseCsv', () => {
+    it('parses simple rows', () => {
+        expect(parseCsv('a,b\nc,d')).toEqual([
+            ['a', 'b'],
+            ['c', 'd'],
+        ]);
+    });
+
+    it('handles quoted fields with commas and quotes', () => {
+        expect(parseCsv('"Doe, Jane",jane@x.com\n"Doe, ""Big"" Jim",jim@x.com')).toEqual([
+            ['Doe, Jane', 'jane@x.com'],
+            ['Doe, "Big" Jim', 'jim@x.com'],
+        ]);
+    });
+
+    it('handles CRLF line endings and trailing newline', () => {
+        expect(parseCsv('a,b\r\nc,d\r\n')).toEqual([
+            ['a', 'b'],
+            ['c', 'd'],
+        ]);
+    });
+
+    it('ignores empty rows', () => {
+        expect(parseCsv('a,b\n\n\nc,d\n')).toEqual([
+            ['a', 'b'],
+            ['c', 'd'],
+        ]);
+    });
+
+    it('returns [] for non-string input', () => {
+        expect(parseCsv(null)).toEqual([]);
+        expect(parseCsv('')).toEqual([]);
+    });
+});
+
+describe('parseAttendeeRows', () => {
+    const header = [['email', 'name', 'roll']];
+
+    it('parses header + rows', () => {
+        const result = parseAttendeeRows([
+            ...header,
+            ['alice@example.com', 'Alice', 'CS21B001'],
+            ['bob@example.com', 'Bob', ''],
+        ]);
+        expect(result.attendees).toEqual([
+            { email: 'alice@example.com', name: 'Alice', rollNumber: 'CS21B001' },
+            { email: 'bob@example.com', name: 'Bob', rollNumber: undefined },
+        ]);
+        expect(result.errors).toEqual([]);
+        expect(result.skipped).toBe(0);
+    });
+
+    it('treats headerless csv as email-first', () => {
+        const result = parseAttendeeRows([
+            ['alice@example.com', 'Alice'],
+            ['bob@example.com', 'Bob'],
+        ]);
+        expect(result.attendees).toHaveLength(2);
+        expect(result.attendees[0]).toEqual({
+            email: 'alice@example.com',
+            name: 'Alice',
+            rollNumber: undefined,
+        });
+    });
+
+    it('reports invalid and missing emails as errors', () => {
+        const result = parseAttendeeRows([...header, ['not-an-email', 'Nope'], ['', 'No Email']]);
+        expect(result.attendees).toHaveLength(0);
+        expect(result.errors).toHaveLength(2);
+        expect(result.errors[0]).toContain('invalid email');
+    });
+
+    it('skips duplicates against existing registrations', () => {
+        const result = parseAttendeeRows(
+            [...header, ['alice@example.com', 'Alice'], ['ALICE@example.com', 'Alice Again']],
+            ['alice@example.com'],
+        );
+        expect(result.attendees).toHaveLength(0);
+        expect(result.skipped).toBe(2);
+    });
+
+    it('normalizes email case', () => {
+        const result = parseAttendeeRows([['CAROL@Example.Com', 'Carol']]);
+        expect(result.attendees[0].email).toBe('carol@example.com');
+    });
+
+    it('returns empty result for empty input', () => {
+        expect(parseAttendeeRows([])).toEqual({ attendees: [], errors: [], skipped: 0 });
+    });
+});
+
+describe('participantIdForEmail', () => {
+    it('is stable and case-insensitive', () => {
+        expect(participantIdForEmail('Alice@Example.com')).toBe(
+            participantIdForEmail('alice@example.com'),
+        );
+        expect(participantIdForEmail('x@y.com')).toHaveLength(20);
+    });
+});

--- a/app/src/lib/__tests__/csvImport.test.js
+++ b/app/src/lib/__tests__/csvImport.test.js
@@ -1,4 +1,4 @@
-import { parseCsv, parseAttendeeRows, participantIdForEmail } from './csvImport';
+import { parseCsv, parseAttendeeRows, participantIdForEmail } from '../csvImport';
 
 describe('parseCsv', () => {
     it('parses simple rows', () => {

--- a/app/src/lib/csvImport.js
+++ b/app/src/lib/csvImport.js
@@ -1,0 +1,128 @@
+/**
+ * CSV bulk attendee import helpers (#559).
+ *
+ * Hand-rolled RFC-4180-ish parser (quoted fields, embedded commas,
+ * CRLF) so no new dependencies are needed in the Expo app.
+ */
+
+/** Splits CSV text into rows of cells, handling quoted fields. */
+export const parseCsv = text => {
+    if (typeof text !== 'string') return [];
+    const rows = [];
+    let row = [];
+    let cell = '';
+    let inQuotes = false;
+
+    const flushRow = () => {
+        row.push(cell);
+        if (row.length > 1 || row[0].trim() !== '') rows.push(row);
+        row = [];
+        cell = '';
+    };
+
+    for (let i = 0; i < text.length; i += 1) {
+        const char = text[i];
+        const next = text[i + 1];
+
+        if (inQuotes) {
+            if (char === '"' && next === '"') {
+                cell += '"';
+                i += 1;
+            } else if (char === '"') {
+                inQuotes = false;
+            } else {
+                cell += char;
+            }
+        } else if (char === '"') {
+            inQuotes = true;
+        } else if (char === ',') {
+            row.push(cell);
+            cell = '';
+        } else if (char === '\n' || char === '\r') {
+            if (char === '\r' && next === '\n') i += 1;
+            flushRow();
+        } else {
+            cell += char;
+        }
+    }
+
+    if (inQuotes) {
+        cell += '"';
+    }
+    if (cell.length > 0 || row.length > 0) {
+        flushRow();
+    }
+
+    return rows;
+};
+
+/**
+ * Converts parsed CSV rows into validated attendee records.
+ *
+ * Accepts headers: email (required), name, rollNumber / roll_no / roll.
+ * Rows without a valid email are reported as errors, not silently dropped.
+ *
+ * @param rows parsed CSV rows (first row treated as header when it
+ *   contains 'email')
+ * @param existingEmails emails already registered for the event
+ * @returns {{ attendees: Array, errors: Array, skipped: number }}
+ */
+export const parseAttendeeRows = (rows, existingEmails = []) => {
+    const attendees = [];
+    const errors = [];
+    if (!Array.isArray(rows) || rows.length === 0) {
+        return { attendees, errors, skipped: 0 };
+    }
+
+    const headerRow = rows[0].map(cell => cell.trim().toLowerCase());
+    const looksLikeHeader = headerRow.includes('email') || headerRow.includes('e-mail');
+
+    const dataRows = looksLikeHeader ? rows.slice(1) : rows;
+    const col = {
+        email: looksLikeHeader ? headerRow.indexOf('email') : 0,
+        name: looksLikeHeader ? headerRow.findIndex(c => c === 'name' || c === 'full name') : 1,
+        roll: looksLikeHeader ? headerRow.findIndex(c => c.includes('roll')) : 2,
+    };
+
+    const existing = new Set(existingEmails.map(e => e.trim().toLowerCase()));
+    const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    let skipped = 0;
+
+    dataRows.forEach((cells, index) => {
+        const email = String(cells[col.email] ?? '')
+            .trim()
+            .toLowerCase();
+        const name = String(cells[col.name] ?? '').trim() || undefined;
+        const roll = String(cells[col.roll] ?? '').trim() || undefined;
+
+        if (!email) {
+            if (cells.length > 1 || cells[0].trim() !== '') {
+                errors.push(`Row ${index + 2}: missing email.`);
+            }
+            return;
+        }
+        if (!EMAIL_RE.test(email)) {
+            errors.push(`Row ${index + 2}: invalid email "${cells[col.email]}".`);
+            return;
+        }
+        if (existing.has(email)) {
+            skipped += 1;
+            return;
+        }
+
+        attendees.push({ email, name, rollNumber: roll });
+        existing.add(email);
+    });
+
+    return { attendees, errors, skipped };
+};
+
+/** Deterministic participant document id from an email (stable, unique). */
+export const participantIdForEmail = email => {
+    const input = String(email).trim().toLowerCase();
+    let hash = 5381;
+    for (let i = 0; i < input.length; i += 1) {
+        hash = ((hash << 5) + hash + input.charCodeAt(i)) >>> 0;
+    }
+    return ('00000000000000000000' + hash.toString(16)).slice(-20);
+};

--- a/app/src/screens/AttendanceDashboard.js
+++ b/app/src/screens/AttendanceDashboard.js
@@ -10,6 +10,7 @@ import {
     getDoc,
     where,
     updateDoc,
+    setDoc,
 } from 'firebase/firestore';
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
@@ -37,6 +38,7 @@ import { useTheme } from '../lib/ThemeContext';
 import { sendBulkAnnouncement, sendBulkFeedbackRequest } from '../lib/EmailService';
 import PropTypes from 'prop-types';
 import { COLLECTIONS, getEventCheckInsPath, getEventFeedbackPath } from '../lib/firestorePaths';
+import { parseCsv, parseAttendeeRows, participantIdForEmail } from '../lib/csvImport';
 import { useAuth } from '../lib/AuthContext';
 
 export default function AttendanceDashboard({ route, navigation }) {
@@ -66,6 +68,11 @@ export default function AttendanceDashboard({ route, navigation }) {
 
     // Feedback Request Modal State
     const [feedbackModalVisible, setFeedbackModalVisible] = useState(false);
+
+    // CSV Bulk Import State (#559)
+    const [importModalVisible, setImportModalVisible] = useState(false);
+    const [importCsvText, setImportCsvText] = useState('');
+    const [importing, setImporting] = useState(false);
 
     useEffect(
         () => () => {
@@ -110,6 +117,78 @@ export default function AttendanceDashboard({ route, navigation }) {
             Alert.alert('Error', e.message || 'Failed to send requests.');
         } finally {
             setSending(false);
+        }
+    };
+
+    const handleImportCsv = async () => {
+        if (importing) return;
+        if (!importCsvText.trim()) {
+            Alert.alert('No Data', 'Paste CSV rows containing attendee emails first.');
+            return;
+        }
+
+        setImporting(true);
+        try {
+            const rows = parseCsv(importCsvText);
+
+            const existingSnapshot = await participantService.fetchParticipantsOnce(db, eventId);
+            const existingEmails = (existingSnapshot || [])
+                .map(p => p.email)
+                .filter(email => typeof email === 'string');
+
+            const { attendees, errors, skipped } = parseAttendeeRows(rows, existingEmails);
+
+            if (errors.length > 0 && attendees.length === 0) {
+                Alert.alert(
+                    'Invalid CSV',
+                    errors.slice(0, 8).join('\n') +
+                        (errors.length > 8 ? `\n…and ${errors.length - 8} more.` : ''),
+                );
+                setImporting(false);
+                return;
+            }
+
+            const CHUNK = 450;
+            for (let i = 0; i < attendees.length; i += CHUNK) {
+                const chunk = attendees.slice(i, i + CHUNK);
+                await Promise.all(
+                    chunk.map(attendee =>
+                        setDoc(
+                            doc(
+                                db,
+                                COLLECTIONS.EVENTS,
+                                eventId,
+                                'participants',
+                                participantIdForEmail(attendee.email),
+                            ),
+                            {
+                                email: attendee.email,
+                                name: attendee.name || '',
+                                rollNumber: attendee.rollNumber || '',
+                                attended: false,
+                                checkInMethod: 'bulk-import',
+                                importedAt: new Date().toISOString(),
+                            },
+                        ),
+                    ),
+                );
+            }
+
+            setImportModalVisible(false);
+            setImportCsvText('');
+            Alert.alert(
+                'Import Complete',
+                `${attendees.length} attendee${attendees.length === 1 ? '' : 's'} imported, ` +
+                    `${skipped} already registered.` +
+                    (errors.length > 0
+                        ? `\n${errors.length} invalid row${errors.length === 1 ? '' : 's'} skipped.`
+                        : ''),
+            );
+        } catch (e) {
+            console.error(e);
+            Alert.alert('Error', e.message || 'Failed to import attendees.');
+        } finally {
+            setImporting(false);
         }
     };
 
@@ -737,6 +816,29 @@ export default function AttendanceDashboard({ route, navigation }) {
                                 </>
                             )}
                         </TouchableOpacity>
+
+                        {/* CSV Bulk Import Button (#559) */}
+                        <TouchableOpacity
+                            style={[
+                                styles.exportBtn,
+                                styles.premiumBtn,
+                                {
+                                    borderColor: theme.colors.primary,
+                                    backgroundColor: theme.colors.surface,
+                                },
+                            ]}
+                            onPress={() => setImportModalVisible(true)}
+                            disabled={importing}
+                        >
+                            <Ionicons
+                                name="document-attach-outline"
+                                size={24}
+                                color={theme.colors.primary}
+                            />
+                            <Text style={[styles.exportBtnText, { color: theme.colors.primary }]}>
+                                Import CSV
+                            </Text>
+                        </TouchableOpacity>
                     </View>
                 </View>
 
@@ -941,6 +1043,96 @@ export default function AttendanceDashboard({ route, navigation }) {
                                         />
                                         <Text style={[styles.modalButtonText, { color: '#fff' }]}>
                                             Send Emails
+                                        </Text>
+                                    </>
+                                )}
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                </View>
+            </Modal>
+
+            {/* CSV Bulk Import Modal (#559) */}
+            <Modal
+                animationType="slide"
+                transparent
+                visible={importModalVisible}
+                onRequestClose={() => setImportModalVisible(false)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View
+                        style={[styles.modalContainer, { backgroundColor: theme.colors.surface }]}
+                    >
+                        <View style={styles.modalHeader}>
+                            <Text style={[styles.modalTitle, { color: theme.colors.text }]}>
+                                Import Attendees from CSV
+                            </Text>
+                            <TouchableOpacity onPress={() => setImportModalVisible(false)}>
+                                <Ionicons name="close" size={24} color={theme.colors.text} />
+                            </TouchableOpacity>
+                        </View>
+
+                        <Text style={[styles.modalSubtitle, { color: theme.colors.textSecondary }]}>
+                            Paste rows with an email column: email,name,roll. Rows are validated;
+                            duplicate and invalid emails are skipped.
+                        </Text>
+
+                        <TextInput
+                            style={[
+                                styles.importInput,
+                                {
+                                    backgroundColor: theme.colors.background,
+                                    borderColor: theme.colors.border,
+                                    color: theme.colors.text,
+                                },
+                            ]}
+                            multiline
+                            placeholder={'alice@example.com,Alice,CS21B001\nbob@example.com,Bob'}
+                            placeholderTextColor={theme.colors.textSecondary}
+                            value={importCsvText}
+                            onChangeText={setImportCsvText}
+                        />
+
+                        <View style={styles.modalActions}>
+                            <TouchableOpacity
+                                style={[
+                                    styles.modalButton,
+                                    {
+                                        backgroundColor: theme.colors.surface,
+                                        borderWidth: 1,
+                                        borderColor: theme.colors.border,
+                                        flex: 1,
+                                    },
+                                ]}
+                                onPress={() => setImportModalVisible(false)}
+                            >
+                                <Text
+                                    style={[styles.modalButtonText, { color: theme.colors.text }]}
+                                >
+                                    Cancel
+                                </Text>
+                            </TouchableOpacity>
+
+                            <TouchableOpacity
+                                style={[
+                                    styles.modalButton,
+                                    { backgroundColor: theme.colors.primary, flex: 1 },
+                                ]}
+                                onPress={handleImportCsv}
+                                disabled={importing}
+                            >
+                                {importing ? (
+                                    <ActivityIndicator color="#fff" />
+                                ) : (
+                                    <>
+                                        <Ionicons
+                                            name="cloud-upload-outline"
+                                            size={16}
+                                            color="#fff"
+                                            style={{ marginRight: 6 }}
+                                        />
+                                        <Text style={[styles.modalButtonText, { color: '#fff' }]}>
+                                            Import
                                         </Text>
                                     </>
                                 )}
@@ -1238,6 +1430,20 @@ const styles = StyleSheet.create({
         marginBottom: 20,
     },
     modalTitle: { fontSize: 20, fontWeight: 'bold' },
+    modalSubtitle: { fontSize: 13, marginBottom: 16, lineHeight: 18 },
+    modalActions: {
+        flexDirection: 'row',
+        gap: 12,
+        marginTop: 16,
+    },
+    importInput: {
+        borderWidth: 1,
+        borderRadius: 12,
+        padding: 12,
+        minHeight: 140,
+        textAlignVertical: 'top',
+        fontSize: 14,
+    },
     inputLabel: { fontSize: 14, marginBottom: 8, fontWeight: '600' },
     input: {
         borderWidth: 1,


### PR DESCRIPTION
Closes #559

## Problem
Organizers could export attendance but had no way to bulk-register attendees (club events, guest lists, imported rosters) — only one-by-one RSVP.

## Changes
- **app/src/lib/csvImport.js** (new, zero dependencies — works in React Native):
  - RFC-4180-ish `parseCsv`: quoted fields, embedded commas, escaped quotes, CRLF
  - `parseAttendeeRows`: required valid email (invalid/missing reported per-row), optional name/rollNumber columns, header-aware (email/name/roll variants) or headerless email-first, dedupes against existing registrations, lowercases emails
  - `participantIdForEmail`: deterministic 20-char FNV-1a hex id (stable doc ids; `crypto` is not available in RN)
- **app/src/screens/AttendanceDashboard.js**: "Import CSV" button opens a modal to paste the CSV — validation preview (errors and skipped counts surfaced), writes in 450-row chunks to `events/{eventId}/participants/{hash}` with `attended: false` and `checkInMethod: 'bulk-import'`, so imported attendees show up instantly in attendance/check-in.
- **app/src/lib/__tests__/csvImport.test.js**: 11 tests (parsing edge cases, header/headerless, invalid rows, dedupe, normalization, stable ids).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk attendee import from pasted CSV data.
  * Supports quoted fields, escaped quotes, commas, and standard line endings.
  * Automatically validates email addresses, detects headers, skips duplicates, and reports invalid rows.
  * Displays import progress, completion counts, skipped entries, and errors.
  * Disables related actions while an import is processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->