### PR TITLE
feat: email verification for email/password signup (#691)

### DIFF
--- a/app/src/lib/AuthContext.js
+++ b/app/src/lib/AuthContext.js
@@ -6,6 +6,8 @@ import {
     signOut as firebaseSignOut,
     onAuthStateChanged,
     signInWithEmailAndPassword,
+    sendEmailVerification,
+    reload,
 } from 'firebase/auth';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
@@ -18,6 +20,13 @@ import { upsertPublicProfile } from './publicProfile';
 const AuthContext = createContext({});
 
 export const useAuth = () => useContext(AuthContext);
+
+export const createEmailNotVerifiedError = () => {
+    const error = new Error('Please verify your email before signing in.');
+    error.code = 'auth/email-not-verified';
+    error.name = 'AuthError';
+    return error;
+};
 
 export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
@@ -258,13 +267,27 @@ export const AuthProvider = ({ children }) => {
 
     // --- Auth Actions ---
 
+    // Emulator mode cannot send real verification emails, so verification
+    // gating is skipped there (Google emulator flows rely on signUp).
+    const isEmulatorMode = process.env.EXPO_PUBLIC_USE_EMULATORS === 'true';
+
     const signIn = useCallback(
         async (email, password) => {
             const result = await signInWithEmailAndPassword(auth, email, password);
-            await saveAccount(result.user, 'password', password); // Auto-save with password
+            const { user } = result;
+
+            if (!isEmulatorMode) {
+                await reload(user);
+                if (!user.emailVerified) {
+                    await firebaseSignOut(auth);
+                    throw createEmailNotVerifiedError();
+                }
+            }
+
+            await saveAccount(user, 'password', password); // Auto-save with password
             return result;
         },
-        [saveAccount],
+        [saveAccount, isEmulatorMode],
     );
 
     const signUp = useCallback(
@@ -288,10 +311,26 @@ export const AuthProvider = ({ children }) => {
             await upsertPublicProfile(db, user.uid, userProfile);
 
             await saveAccount(user, 'password', password); // Auto-save with password
-            return result;
+
+            if (!isEmulatorMode) {
+                await sendEmailVerification(user);
+                // Keep the user on the auth screen until they verify their
+                // email, so they cannot access the app unverified.
+                await firebaseSignOut(auth);
+            }
+
+            return { ...result, verificationEmailSent: !isEmulatorMode };
         },
-        [saveAccount],
+        [saveAccount, isEmulatorMode],
     );
+
+    // Re-authenticates the unverified account, resends the verification
+    // email, and signs out again, leaving the user on the auth screen.
+    const resendVerificationEmail = useCallback(async (email, password) => {
+        const { user } = await signInWithEmailAndPassword(auth, email, password);
+        await sendEmailVerification(user);
+        await firebaseSignOut(auth);
+    }, []);
 
     const signOut = useCallback(() => {
         return firebaseSignOut(auth);
@@ -311,6 +350,7 @@ export const AuthProvider = ({ children }) => {
             loading,
             signIn,
             signUp,
+            resendVerificationEmail,
             signOut,
             savedAccounts,
             switchAccount,
@@ -324,6 +364,7 @@ export const AuthProvider = ({ children }) => {
         loading,
         signIn,
         signUp,
+        resendVerificationEmail,
         signOut,
         savedAccounts,
         switchAccount,

--- a/app/src/screens/AuthScreen.js
+++ b/app/src/screens/AuthScreen.js
@@ -43,6 +43,8 @@ const FIREBASE_ERROR_MESSAGES = {
     'auth/network-request-failed': 'Network error. Please check your connection.',
     'auth/user-disabled': 'This account has been disabled.',
     'auth/operation-not-allowed': 'This sign-in method is not enabled.',
+    'auth/email-not-verified': 'Please verify your email before signing in.',
+    'auth/verification-email-sent': 'Verification email sent. Check your inbox.',
 };
 
 function getFirebaseErrorMessage(error) {
@@ -187,8 +189,9 @@ export default function AuthScreen() {
 
     const [touched, setTouched] = useState({ email: false, password: false, name: false });
 
-    const { signIn, signUp, saveGoogleAccountCredentials } = useAuth();
+    const { signIn, signUp, resendVerificationEmail, saveGoogleAccountCredentials } = useAuth();
     const [successMessage, setSuccessMessage] = useState('');
+    const [verificationEmail, setVerificationEmail] = useState('');
 
     const [request, response, promptAsync] = Google.useAuthRequest({
         androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
@@ -270,6 +273,7 @@ export default function AuthScreen() {
     const handleEmailChange = text => {
         setEmail(text);
         setSuccessMessage('');
+        setVerificationEmail('');
         if (touched.email) {
             setEmailError(validateEmail(text));
         }
@@ -341,8 +345,37 @@ export default function AuthScreen() {
             if (isLogin) {
                 await signIn(email.trim(), password);
             } else {
-                await signUp(email.trim(), password, { displayName: name.trim() });
+                const result = await signUp(email.trim(), password, { displayName: name.trim() });
+                if (result.verificationEmailSent) {
+                    setSuccessMessage(
+                        'Account created! A verification email has been sent to your inbox. Please verify your email before signing in.',
+                    );
+                    setIsLogin(true);
+                    setPassword('');
+                }
             }
+        } catch (error) {
+            if (error.code === 'auth/email-not-verified') {
+                setVerificationEmail(email.trim());
+            }
+            const msg = getFirebaseErrorMessage(error);
+            routeAuthError(error, msg, setEmailError, setPasswordError);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleResendVerification = async () => {
+        const targetEmail = verificationEmail || email.trim();
+        const eErr = validateEmail(targetEmail);
+        if (eErr) {
+            setEmailError(eErr);
+            return;
+        }
+        setLoading(true);
+        try {
+            await resendVerificationEmail(targetEmail, password);
+            setSuccessMessage('Verification email sent. Check your inbox.');
         } catch (error) {
             const msg = getFirebaseErrorMessage(error);
             routeAuthError(error, msg, setEmailError, setPasswordError);
@@ -526,6 +559,46 @@ export default function AuthScreen() {
                             <Text style={[styles.successText, { color: theme.colors.success }]}>
                                 {successMessage}
                             </Text>
+                        ) : null}
+                        {verificationEmail ? (
+                            <View
+                                style={[
+                                    styles.verificationContainer,
+                                    {
+                                        backgroundColor: theme.colors.warning + '22',
+                                        borderColor: theme.colors.warning + '55',
+                                    },
+                                ]}
+                            >
+                                <Ionicons
+                                    name="mail-unread-outline"
+                                    size={18}
+                                    color={theme.colors.warning}
+                                />
+                                <Text
+                                    style={[
+                                        styles.verificationText,
+                                        { color: theme.colors.warning },
+                                    ]}
+                                >
+                                    Verification required for {verificationEmail}. Check your inbox
+                                    and click the link, then sign in again.
+                                </Text>
+                                <TouchableOpacity
+                                    onPress={handleResendVerification}
+                                    disabled={loading}
+                                    style={styles.resendButton}
+                                >
+                                    <Text
+                                        style={[
+                                            styles.resendButtonText,
+                                            { color: theme.colors.primary },
+                                        ]}
+                                    >
+                                        Resend verification email
+                                    </Text>
+                                </TouchableOpacity>
+                            </View>
                         ) : null}
                         {isLogin && (
                             <TouchableOpacity
@@ -731,5 +804,27 @@ const styles = StyleSheet.create({
         fontSize: 12,
         marginTop: -8,
         marginLeft: 4,
+    },
+    verificationContainer: {
+        marginTop: 12,
+        borderRadius: 12,
+        borderWidth: 1,
+        paddingHorizontal: 12,
+        paddingVertical: 10,
+        gap: 4,
+    },
+    verificationText: {
+        fontSize: 12,
+        lineHeight: 17,
+        flexShrink: 1,
+    },
+    resendButton: {
+        marginTop: 4,
+        alignSelf: 'flex-start',
+    },
+    resendButtonText: {
+        fontSize: 13,
+        fontWeight: '700',
+        textDecorationLine: 'underline',
     },
 });


### PR DESCRIPTION
Closes #691

## What
Email/password signup now requires email verification before the user can access the app.

**`app/src/lib/AuthContext.js`**
- `signUp`: sends a Firebase `sendEmailVerification` email after account creation, then signs the new user out — they stay on the auth screen with a "check your inbox" message until verified
- `signIn`: `reload()`s the user and blocks access with a new `auth/email-not-verified` error when `emailVerified` is false (signs out so the app never proceeds in an unverified session)
- `resendVerificationEmail(email, password)`: re-authenticates, resends the verification email, signs out again
- Emulator mode (`EXPO_PUBLIC_USE_EMULATORS`) skips verification gating — real emails can't be delivered, and the Google emulator flows rely on `signUp`

**`app/src/screens/AuthScreen.js`**
- Verification-required banner (email shown, "check your inbox and click the link, then sign in again") with a **Resend verification email** button
- Signup success now switches to the sign-in tab and shows "Account created! A verification email has been sent…"
- `auth/email-not-verified` / `auth/verification-email-sent` messages added to the error map

Flow: sign up → verification email sent → user sees inbox message → clicks link → signs in → app checks `emailVerified` → grants access. Resend available if the first email is lost.

## Verify
- `node --check` on both files, prettier clean
- Emulator/Google flows unchanged (gated only in non-emulator mode)