### PR TITLE
fix: prevent duplicate RSVP registrations (#735)

### DIFF
--- a/app/src/screens/EventRegistrationFormScreen.js
+++ b/app/src/screens/EventRegistrationFormScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
     View,
     Text,
@@ -34,6 +34,7 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
     const [loading, setLoading] = useState(false);
     const [datePickers, setDatePickers] = useState({});
     const [showConfetti, setShowConfetti] = useState(false);
+    const submittingRef = useRef(false);
     const { width: screenWidth } = Dimensions.get('window');
 
     useEffect(() => {
@@ -59,7 +60,11 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
     };
 
     const handleSubmit = async () => {
-        if (loading) return;
+        if (loading || submittingRef.current) return;
+
+        // Guard against rapid double-taps: state updates are async, so two
+        // taps in the same tick can both pass the `loading` check.
+        submittingRef.current = true;
 
         if (!validate()) return;
 
@@ -106,6 +111,10 @@ export default function EventRegistrationFormScreen({ navigation, route }) {
             Alert.alert('Error', e.message || 'Failed to register.');
         } finally {
             setLoading(false);
+            // Allow a failed attempt to be retried shortly after.
+            setTimeout(() => {
+                submittingRef.current = false;
+            }, 500);
         }
     };
 

--- a/app/src/screens/PaymentScreen.js
+++ b/app/src/screens/PaymentScreen.js
@@ -3,7 +3,7 @@ import { httpsCallable } from 'firebase/functions';
 import { getDoc, doc } from 'firebase/firestore';
 import { db, functions } from '../lib/firebaseConfig';
 import { getEarlyBirdInfo } from '../lib/earlyBird';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
     ActivityIndicator,
     Alert,
@@ -28,6 +28,7 @@ export default function PaymentScreen({ route, navigation }) {
     const { theme } = useTheme();
 
     const [loading, setLoading] = useState(false);
+    const submittingRef = useRef(false);
     const [selectedMethod, setSelectedMethod] = useState(null);
     const [utr, setUtr] = useState('');
     const [showUtrInput, setShowUtrInput] = useState(false);
@@ -117,6 +118,8 @@ export default function PaymentScreen({ route, navigation }) {
     };
 
     const processTicketBooking = transactionId => {
+        if (submittingRef.current) return;
+        submittingRef.current = true;
         setLoading(true);
 
         // Simulate Validation Delay
@@ -152,6 +155,7 @@ export default function PaymentScreen({ route, navigation }) {
             } catch (error) {
                 console.error('Payment Error:', error);
                 setLoading(false);
+                submittingRef.current = false;
                 Alert.alert('Payment Failed', 'Something went wrong. Please try again.');
             }
         }, 2000);

--- a/cloud-functions/src/events/index.ts
+++ b/cloud-functions/src/events/index.ts
@@ -216,7 +216,18 @@ const processRegistrationTransaction = async (
     transaction.set(participatingRef, participatingPayload);
 
     if (!isPaid || responses) {
-        const registrationRef = db.collection('registrations').doc();
+        // Deterministic doc id (eventId_userId) so a second registration for
+        // the same event+user writes to the same document, and the
+        // existence guard below rejects duplicates instead of creating a
+        // second registration record that inflates attendee counts.
+        const registrationRef = db.collection('registrations').doc(`${eventId}_${uid}`);
+        const registrationSnap = await transaction.get(registrationRef);
+        if (registrationSnap.exists) {
+            throw new functions.https.HttpsError(
+                'already-exists',
+                'You are already registered for this event.',
+            );
+        }
         const regPayload: any = {
             eventId: eventId,
             eventId_userId: `${eventId}_${uid}`,

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -349,6 +349,37 @@ describe('Firestore Security Rules', () => {
         );
     });
 
+    // Regression for #735: a second full RSVP write for the same event+user
+    // (which would inflate attendee counts) must be rejected. The existing
+    // participant document can only be updated via the restricted status
+    // keys, so a full re-registration payload is denied.
+    test('Duplicate RSVP re-registration write -> denied (Issue #735)', async () => {
+        await seedDocument('events/event1/participants/student1', {
+            userId: 'student1',
+            status: 'attending',
+        });
+        await assertFails(
+            setDoc(doc(getFirestoreContext('student1'), 'events/event1/participants/student1'), {
+                userId: 'student1',
+                name: 'Student One',
+                email: 'student1@example.com',
+                joinedAt: new Date().toISOString(),
+                status: 'attending',
+            }),
+        );
+    });
+
+    test('Re-registration via status-only update -> allowed (Issue #735)', async () => {
+        await seedDocument('events/event1/participants/student1', { status: 'cancelled' });
+        await assertSucceeds(
+            setDoc(
+                doc(getFirestoreContext('student1'), 'events/event1/participants/student1'),
+                { status: 'attending' },
+                { merge: true },
+            ),
+        );
+    });
+
     // ---------------- EVENT CHECK-INS ----------------
 
     test('Club user writes event check-in -> allowed', async () => {


### PR DESCRIPTION
Closes #735

## Problem
Rapid double-taps on "Submit Registration" / "Verify & Book" could produce duplicate registration records: React state updates are async, so two taps in the same tick both pass the `loading` check. Registration records used a random Firestore doc id, so each attempt created a separate `registrations` document for the same event+user, inflating attendee counts and corrupting analytics.

## Changes
**Cloud function (`cloud-functions/src/events/index.ts`)**
- `registrations` docs now use the deterministic id `` `${eventId}_${uid}` `` (already stored as `eventId_userId` in the payload) with an existence check inside the `runTransaction` — a second registration for the same event+user rejects with `already-exists` ("You are already registered for this event.") instead of writing a duplicate record
- Server-side guards remain transactional: participant existence + capacity + early-bird capacity checks are unchanged

**Client double-submit guards**
- `EventRegistrationFormScreen.js`: `submittingRef` short-circuits repeat submissions immediately (the async `setLoading` race); resets 500ms after a failed attempt so retries work
- `PaymentScreen.js`: same guard around `processTicketBooking` — covers the 2s validation delay and the 2.5s success-animation window where the button is re-enabled; released on failure

**Rules tests (`tests/firestore.rules.test.ts`)**
- Full re-registration write for an existing participant doc → denied (only status keys are updatable)
- Cancel → re-join (status-only update) still allowed — cancelling and re-registering intentionally stays possible

## Verify
- `npm run test:rules` (firestore emulator): new regression tests pass
- prettier clean; `node --check` clean on both screens