### PR TITLE
fix: free RSVP check-in and offline sync paths (#753, #754)

### DIFF
--- a/app/src/lib/checkInService.js
+++ b/app/src/lib/checkInService.js
@@ -423,8 +423,11 @@ const syncOfflineCheckInItem = async (item, eventId, organizerId) => {
             'stats.lastCheckInAt': serverTimestamp(),
         }).catch(() => {});
 
-        const registrationRef = doc(db, 'events', eventId, 'registrations', item.userId);
-        await updateDoc(registrationRef, { status: 'attended' }).catch(() => {});
+        const registrationRef = doc(db, 'registrations', `${eventId}_${item.userId}`);
+        await updateDoc(registrationRef, {
+            status: 'attended',
+            checkedInAt: offlineCheckedInAt,
+        }).catch(() => {});
     }
 };
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -338,7 +338,12 @@ service cloud.firestore {
         
         allow update: if request.auth != null && request.auth.uid == participantId &&
           validateAttendanceStatus(request.resource.data) &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'buddyPreference', 'updatedAt']);
+          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'buddyPreference', 'updatedAt'])
+          || (request.auth != null &&
+            (isEventOwner(database, eventId) || isEventOwnerAfter(database, eventId)) &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(
+              ['checkInStatus', 'checkedInAt', 'checkedInBy', 'updatedAt']
+            ));
       }
 
       // Event Check-ins (Contactless Verification)

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -349,6 +349,92 @@ describe('Firestore Security Rules', () => {
         );
     });
 
+    // Regression for #753: free RSVP check-in writes checkInStatus/checkedInAt/
+    // checkedInBy to the participant doc on behalf of the EVENT OWNER. Before
+    // the fix the update rule only allowed the participant themselves, so the
+    // check-in transaction always failed.
+    test('Event owner applies check-in fields to participant -> allowed (Issue #753)', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', { status: 'attending' });
+        await assertSucceeds(
+            setDoc(
+                doc(getFirestoreContext('clubOwner1'), 'events/event1/participants/student1'),
+                {
+                    checkInStatus: 'checked-in',
+                    checkedInAt: serverTimestamp(),
+                    checkedInBy: 'clubOwner1',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
+    test('Non-owner student cannot apply check-in fields to another participant -> denied (Issue #753)', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student2', { status: 'attending' });
+        await assertFails(
+            setDoc(
+                doc(getFirestoreContext('student1'), 'events/event1/participants/student2'),
+                {
+                    checkInStatus: 'checked-in',
+                    checkedInBy: 'student1',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
+    test('Owner cannot rewrite registration payload through update -> denied (Issue #753)', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', { status: 'attending' });
+        await assertFails(
+            setDoc(
+                doc(getFirestoreContext('clubOwner1'), 'events/event1/participants/student1'),
+                {
+                    status: 'attending',
+                    name: 'Student One',
+                    email: 'student1@example.com',
+                    joinedAt: '2026-01-01T00:00:00.000Z',
+                    checkInStatus: 'checked-in',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
+    // Regression for #754: offline check-in sync marks the registration
+    // document (top-level `registrations/{eventId}_{userId}`) as attended.
+    test('Event owner updates registration status -> allowed (Issue #754)', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('registrations/event1_student1', {
+            eventId: 'event1',
+            userId: 'student1',
+            status: 'confirmed',
+        });
+        await assertSucceeds(
+            setDoc(
+                doc(getFirestoreContext('clubOwner1'), 'registrations/event1_student1'),
+                { status: 'attended' },
+                { merge: true },
+            ),
+        );
+    });
+
+    test('Student cannot update another registration record -> denied (Issue #754)', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('registrations/event1_student2', {
+            eventId: 'event1',
+            userId: 'student2',
+            status: 'confirmed',
+        });
+        await assertFails(
+            setDoc(
+                doc(getFirestoreContext('student1'), 'registrations/event1_student2'),
+                { status: 'attended' },
+                { merge: true },
+            ),
+        );
+    });
     // ---------------- EVENT CHECK-INS ----------------
 
     test('Club user writes event check-in -> allowed', async () => {


### PR DESCRIPTION
Closes #753, Closes #754

Two regressions in the same check-in code path:

## #753 — Free RSVP check-in always fails
`checkInParticipant` (organizer action) writes `checkInStatus`/`checkedInAt`/`checkedInBy` to `events/{eventId}/participants/{userId}`, but the participants update rule only allowed the participant themself to touch `status`/`buddyPreference`/`updatedAt` — so the check-in transaction was always denied for free RSVP participants.

**Fix (`firestore.rules`):** event owner/club may now apply the check-in fields (restricted to `checkInStatus`, `checkedInAt`, `checkedInBy`, `updatedAt`). Self-service status updates, `validateAttendanceStatus`, and the restricted-key checks for everyone else are unchanged. The offline sync participant update (previously swallowed by `.catch(() => {})`) benefits from the same fix.

## #754 — Offline sync writes to a non-existent subcollection
`syncOfflineCheckInItem` updated `events/{eventId}/registrations/{userId}` — a subcollection that does not exist in the current data model — so the `attended` status was silently lost.

**Fix (`checkInService.js`):** updates the top-level `registrations/{eventId}_{userId}` document (the deterministic id `registerForEvent` writes since #735) with `status: attended` + `checkedInAt`.

## Tests (`tests/firestore.rules.test.ts`)
- owner applies check-in fields → allowed
- non-owner applies check-in fields → denied
- owner cannot rewrite the registration payload via update (key restriction holds) → denied
- owner updates registration `status: attended` → allowed
- student updates another registration → denied

Run: `npm run test:rules` (firestore emulator; Java required locally — CI runs it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offline check-ins now synchronize attendance status and check-in time correctly.
  * Event owners can update participant check-in details while protected registration information remains secure.
  * Unauthorized check-in and registration updates are blocked.

* **Tests**
  * Added coverage for authorized and unauthorized participant check-in and registration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->