### PR TITLE
Fix #753: Free RSVP check-in denied by Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -336,9 +336,16 @@ service cloud.firestore {
           
         allow delete: if request.auth != null && request.auth.uid == participantId;
         
-        allow update: if request.auth != null && request.auth.uid == participantId &&
-          validateAttendanceStatus(request.resource.data) &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'buddyPreference', 'updatedAt']);
+        allow update: if (
+          (request.auth != null && request.auth.uid == participantId &&
+            validateAttendanceStatus(request.resource.data) &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'buddyPreference', 'updatedAt']))
+          ||
+          (isEventOwner(database, eventId) &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+              'checkInStatus', 'checkedInAt', 'checkedInBy'
+            ]))
+        );
       }
 
       // Event Check-ins (Contactless Verification)

--- a/tests/firestore.rules.test.ts
+++ b/tests/firestore.rules.test.ts
@@ -349,6 +349,44 @@ describe('Firestore Security Rules', () => {
         );
     });
 
+    test('Event owner checks in free RSVP participant -> allowed', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', {
+            status: 'rsvp',
+            userName: 'Student One',
+        });
+        await assertSucceeds(
+            setDoc(
+                doc(getFirestoreContext('clubOwner1'), 'events/event1/participants/student1'),
+                {
+                    checkInStatus: 'checked-in',
+                    checkedInAt: serverTimestamp(),
+                    checkedInBy: 'clubOwner1',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
+    test('Non-owner student checks in another participant -> denied', async () => {
+        await seedDocument('events/event1', { title: 'Tech Fest', ownerId: 'clubOwner1' });
+        await seedDocument('events/event1/participants/student1', {
+            status: 'rsvp',
+            userName: 'Student One',
+        });
+        await assertFails(
+            setDoc(
+                doc(getFirestoreContext('student2'), 'events/event1/participants/student1'),
+                {
+                    checkInStatus: 'checked-in',
+                    checkedInAt: serverTimestamp(),
+                    checkedInBy: 'student2',
+                },
+                { merge: true },
+            ),
+        );
+    });
+
     // ---------------- EVENT CHECK-INS ----------------
 
     test('Club user writes event check-in -> allowed', async () => {


### PR DESCRIPTION
## Problem
`checkInParticipant()` (checkInService.js) runs as the **organizer** and writes `checkInStatus`/`checkedInAt`/`checkedInBy` to the participant doc, but `firestore.rules` only allow a participant to update their **own** doc with keys `status`/`buddyPreference`/`updatedAt`. Since Firestore transactions are atomic, this single denied write fails the whole transaction → free-RSVP check-in always fails.

## Fix
Extended the `participants/{participantId}` `allow update` rule so the event owner (`isEventOwner`) may write the three check-in keys:

```
(participant updates own: status/buddyPreference/updatedAt)
|| (event owner: checkInStatus/checkedInAt/checkedInBy)
```

`checkIns` writes were already permitted for owners; only the participant-doc write was blocked.

## Verification
- Added 2 rules tests: owner check-in write → allowed; non-owner → denied
- `firebase emulators:exec --only firestore "jest tests/firestore.rules.test.ts"` → 48/52 pass; the 4 remaining failures are pre-existing on main (confirmed by baseline run), same behaviour before/after

Fixes #753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event owners can check in RSVP participants and record check-in details.
  * Participants retain the ability to update attendance-related information within permitted limits.

* **Bug Fixes**
  * Prevented unrelated students from modifying participant check-in information.

* **Tests**
  * Added coverage for authorized and unauthorized check-in updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->